### PR TITLE
CENPLAT-23913: Add gradient array, gradient reader, and split out category attribute data tests

### DIFF
--- a/omf-python/src/array.rs
+++ b/omf-python/src/array.rs
@@ -79,3 +79,14 @@ impl PyNameArray {
         self.0.item_count()
     }
 }
+
+#[gen_stub_pyclass]
+#[pyclass(name = "GradientArray")]
+pub struct PyGradientArray(pub Array<array_type::Gradient>);
+#[pymethods]
+impl PyGradientArray {
+    #[getter]
+    fn item_count(&self) -> u64 {
+        self.0.item_count()
+    }
+}

--- a/omf-python/src/attribute.rs
+++ b/omf-python/src/attribute.rs
@@ -1,4 +1,4 @@
-use crate::array::{PyColorArray, PyIndexArray, PyNameArray};
+use crate::array::{PyColorArray, PyGradientArray, PyIndexArray, PyNameArray};
 use omf::{Attribute, AttributeData, Location};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -87,6 +87,18 @@ impl PyAttributeDataCategory {
     fn names(&self) -> PyResult<PyNameArray> {
         match &self.0 {
             AttributeData::Category { names, .. } => Ok(PyNameArray(names.clone())),
+            _ => Err(PyValueError::new_err(
+                "AttributeData variant is not supported",
+            )),
+        }
+    }
+
+    #[getter]
+    fn gradient(&self) -> PyResult<Option<PyGradientArray>> {
+        match &self.0 {
+            AttributeData::Category { gradient, .. } => {
+                Ok(gradient.as_ref().map(|g| PyGradientArray(g.clone())))
+            }
             _ => Err(PyValueError::new_err(
                 "AttributeData variant is not supported",
             )),

--- a/omf-python/src/attribute.rs
+++ b/omf-python/src/attribute.rs
@@ -69,11 +69,19 @@ impl PyAttribute {
 }
 
 #[pyclass(name = "AttributeDataCategory")]
+/// Category data.
+///
+/// A name is required for each category, a color is optional, and other values can be attached
+/// as sub-attributes.
 pub struct PyAttributeDataCategory(AttributeData);
 
 #[pymethods]
 impl PyAttributeDataCategory {
     #[getter]
+    /// Array with `Index` type storing the category indices.
+    ///
+    /// Values are indices into the `names` array, `colors` array, and any sub-attributes,
+    /// and must be within range for them.
     fn values(&self) -> PyResult<PyIndexArray> {
         match &self.0 {
             AttributeData::Category { values, .. } => Ok(PyIndexArray(values.clone())),
@@ -84,6 +92,7 @@ impl PyAttributeDataCategory {
     }
 
     #[getter]
+    /// Array with `Name` type storing category names.
     fn names(&self) -> PyResult<PyNameArray> {
         match &self.0 {
             AttributeData::Category { names, .. } => Ok(PyNameArray(names.clone())),
@@ -94,6 +103,10 @@ impl PyAttributeDataCategory {
     }
 
     #[getter]
+    /// Optional array with `Gradient` type storing category colors.
+    ///
+    /// If present, must be the same length as `names`. If absent then the importing
+    /// application should invent colors.
     fn gradient(&self) -> PyResult<Option<PyGradientArray>> {
         match &self.0 {
             AttributeData::Category { gradient, .. } => {
@@ -106,6 +119,11 @@ impl PyAttributeDataCategory {
     }
 
     #[getter]
+    /// Additional attributes that use the same indices.
+    ///
+    /// This could be used to store the density of rock types in a lithology attribute for
+    /// example. The location field of these attributes must be `Categories`.
+    /// They must have the same length as `names`.
     fn attributes(&self) -> PyResult<Vec<PyAttribute>> {
         match &self.0 {
             AttributeData::Category { attributes, .. } => {

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -1,5 +1,6 @@
 use crate::array::{
-    PyColorArray, PyIndexArray, PyNameArray, PySegmentArray, PyTriangleArray, PyVertexArray,
+    PyColorArray, PyGradientArray, PyIndexArray, PyNameArray, PySegmentArray, PyTriangleArray,
+    PyVertexArray,
 };
 use crate::element::PyColor;
 use crate::PyProject;
@@ -104,6 +105,14 @@ impl PyReader {
             .array_colors(&array.0)
             .map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?
             .map(|r| r.map(|c| c.map(PyColor)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
+    }
+
+    pub fn array_gradient(&self, array: &PyGradientArray) -> PyResult<Vec<[u8; 4]>> {
+        self.0
+            .array_gradient(&array.0)
+            .map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -55,6 +55,11 @@ impl PyReader {
     }
 
     #[getter]
+    /// Reads, validates, and returns the root `Project` object from the file.
+    ///
+    /// Fails with an error if an IO error occurs, the `json_bytes` limit is exceeded, or validation
+    /// fails. Validation warnings are returned alongside the project if successful or included
+    /// with the errors if not.
     fn project(&self) -> PyResult<PyProject> {
         let (project, problems) = self
             .0
@@ -68,6 +73,7 @@ impl PyReader {
         Ok(PyProject(project))
     }
 
+    /// Read a Vertex array.
     pub fn array_vertices(&self, array: &PyVertexArray) -> PyResult<Vec<[f64; 3]>> {
         self.0
             .array_vertices(&array.0)
@@ -76,6 +82,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read a Segment array.
     pub fn array_segments(&self, array: &PySegmentArray) -> PyResult<Vec<[u32; 2]>> {
         self.0
             .array_segments(&array.0)
@@ -84,6 +91,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read an Index array.
     pub fn array_indices(&self, array: &PyIndexArray) -> PyResult<Vec<Option<u32>>> {
         self.0
             .array_indices(&array.0)
@@ -92,6 +100,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read a Triangle array.
     pub fn array_triangles(&self, array: &PyTriangleArray) -> PyResult<Vec<[u32; 3]>> {
         self.0
             .array_triangles(&array.0)
@@ -100,6 +109,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read a Color array.
     pub fn array_color(&self, array: &PyColorArray) -> PyResult<Vec<Option<PyColor>>> {
         self.0
             .array_colors(&array.0)
@@ -109,6 +119,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read a Gradient array.
     pub fn array_gradient(&self, array: &PyGradientArray) -> PyResult<Vec<[u8; 4]>> {
         self.0
             .array_gradient(&array.0)
@@ -117,6 +128,7 @@ impl PyReader {
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }
 
+    /// Read a Name array.
     pub fn array_names(&self, array: &PyNameArray) -> PyResult<Vec<String>> {
         self.0
             .array_names(&array.0)

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -11,7 +11,9 @@ mod omf1;
 mod project;
 mod validate;
 
-use array::{PyColorArray, PyIndexArray, PyNameArray, PyTriangleArray, PyVertexArray};
+use array::{
+    PyColorArray, PyGradientArray, PyIndexArray, PyNameArray, PyTriangleArray, PyVertexArray,
+};
 use attribute::{PyAttribute, PyAttributeDataCategory, PyAttributeDataColor};
 use element::{PyColor, PyElement};
 use file::reader::{PyLimits, PyReader};
@@ -35,6 +37,7 @@ fn omf_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyColor>()?;
     m.add_class::<PyColorArray>()?;
     m.add_class::<PyIndexArray>()?;
+    m.add_class::<PyGradientArray>()?;
     m.add_class::<PyVertexArray>()?;
     m.add_class::<PyTriangleArray>()?;
     m.add_class::<PyNameArray>()?;

--- a/omf-python/tests/test_category_attribute.py
+++ b/omf-python/tests/test_category_attribute.py
@@ -9,7 +9,7 @@ class TestCategoryAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
 
-    def test_should_return_categories_attribute(self) -> None:
+    def test_should_return_category_attribute_details(self) -> None:
         attributes = self.reader.project.elements[1].attributes
 
         self.assertEqual(len(attributes), 3)
@@ -34,7 +34,7 @@ class TestCategoryAttribute(TestCase):
 
         self.assertEqual(attribute.location, "Vertices")
 
-    def test_should_return_categories_attribute_data(self) -> None:
+    def test_should_return_category_attribute_array_instances(self) -> None:
         attributes = self.reader.project.elements[1].attributes
 
         attribute_data = attributes[0].get_data()
@@ -46,7 +46,7 @@ class TestCategoryAttribute(TestCase):
         self.assertIsInstance(attribute_data.gradient, omf_python.GradientArray)
         self.assertIsInstance(attribute_data.attributes[0], omf_python.Attribute)
 
-    def test_should_return_category_values(self) -> None:
+    def test_should_return_category_attribute_expected_values(self) -> None:
         attribute_data = self.reader.project.elements[1].attributes[0].get_data()
 
         values = self.reader.array_indices(attribute_data.values)

--- a/omf-python/tests/test_category_attribute.py
+++ b/omf-python/tests/test_category_attribute.py
@@ -10,28 +10,21 @@ class TestCategoryAttribute(TestCase):
         self.reader = omf_python.Reader(one_of_everything)
 
     def test_should_return_categories_attribute(self) -> None:
-        # Given I get the attributes for my PointSet
         attributes = self.reader.project.elements[1].attributes
 
-        # Then I should have three attributes
         self.assertEqual(len(attributes), 3)
 
-        # And each attribute should be of the type Attribute
         for attribute in attributes:
             self.assertIsInstance(attribute, omf_python.Attribute)
 
-        # And the first attribute should be named "Categories"
         attribute = attributes[0]
 
         self.assertEqual(attribute.name, "Categories")
 
-        # And it should have a description
         self.assertEqual(attribute.description, "Divides the points into top and base.")
 
-        # And its units should be whatever
         self.assertEqual(attribute.units, "whatever")
 
-        # And it should have basic metadata
         metadata_string = attribute.metadata
         metadata = json.loads(metadata_string)
         expected_metadata = {
@@ -39,52 +32,39 @@ class TestCategoryAttribute(TestCase):
         }
         self.assertEqual(metadata, expected_metadata)
 
-        # And the attribute should have a location
         self.assertEqual(attribute.location, "Vertices")
 
     def test_should_return_categories_attribute_data(self) -> None:
-        # Given I get the attributes for my PointSet
         attributes = self.reader.project.elements[1].attributes
 
-        # And I get the data from the first Attribute
         attribute_data = attributes[0].get_data()
 
-        # Then the data should be of type AttributeDataCategory
         self.assertIsInstance(attribute_data, omf_python.AttributeDataCategory)
 
-        # Then the attribute data should contain: Values, Names, Gradient and Attributes
         self.assertIsInstance(attribute_data.values, omf_python.IndexArray)
         self.assertIsInstance(attribute_data.names, omf_python.NameArray)
         self.assertIsInstance(attribute_data.gradient, omf_python.GradientArray)
         self.assertIsInstance(attribute_data.attributes[0], omf_python.Attribute)
 
     def test_should_return_category_values(self) -> None:
-        # Given I have the category attribute data
         attribute_data = self.reader.project.elements[1].attributes[0].get_data()
 
-        # When I read the values for the category
         values = self.reader.array_indices(attribute_data.values)
 
-        # Then I should get the expected results
         expected_values = [0, 0, 0, 0, 1]
         self.assertEqual(values, expected_values)
 
-        # And when I read the names
         names = self.reader.array_names(attribute_data.names)
 
-        # Then I should get the expected names back
         expected_names = ["Base", "Top"]
         self.assertEqual(names, expected_names)
 
-        # And when I read the gradient
         gradient = self.reader.array_gradient(attribute_data.gradient)
 
         expected_gradient = [[255, 128, 0, 255], [0, 128, 255, 255]]
         self.assertEqual(gradient, expected_gradient)
 
-        # And when I get the category sub-attributes
         category_attributes = attribute_data.attributes
 
-        # There should be one attribute
         self.assertEqual(len(category_attributes), 1)
         self.assertIsInstance(category_attributes[0], omf_python.Attribute)

--- a/omf-python/tests/test_category_attribute.py
+++ b/omf-python/tests/test_category_attribute.py
@@ -1,0 +1,90 @@
+import json
+import omf_python
+from os import path
+from unittest import TestCase
+
+class TestCategoryAttribute(TestCase):
+    def setUp(self) -> None:
+        omf_dir = path.join(path.dirname(__file__), "data")
+        one_of_everything = path.join(omf_dir, "one_of_everything.omf")
+        self.reader = omf_python.Reader(one_of_everything)
+
+    def test_should_return_categories_attribute(self) -> None:
+        # Given I get the attributes for my PointSet
+        attributes = self.reader.project.elements[1].attributes
+
+        # Then I should have three attributes
+        self.assertEqual(len(attributes), 3)
+
+        # And each attribute should be of the type Attribute
+        for attribute in attributes:
+            self.assertIsInstance(attribute, omf_python.Attribute)
+
+        # And the first attribute should be named "Categories"
+        attribute = attributes[0]
+
+        self.assertEqual(attribute.name, "Categories")
+
+        # And it should have a description
+        self.assertEqual(attribute.description, "Divides the points into top and base.")
+
+        # And its units should be whatever
+        self.assertEqual(attribute.units, "whatever")
+
+        # And it should have basic metadata
+        metadata_string = attribute.metadata
+        metadata = json.loads(metadata_string)
+        expected_metadata = {
+            "key": "value"
+        }
+        self.assertEqual(metadata, expected_metadata)
+
+        # And the attribute should have a location
+        self.assertEqual(attribute.location, "Vertices")
+
+    def test_should_return_categories_attribute_data(self) -> None:
+        # Given I get the attributes for my PointSet
+        attributes = self.reader.project.elements[1].attributes
+
+        # And I get the data from the first Attribute
+        attribute_data = attributes[0].get_data()
+
+        # Then the data should be of type AttributeDataCategory
+        self.assertIsInstance(attribute_data, omf_python.AttributeDataCategory)
+
+        # Then the attribute data should contain: Values, Names, Gradient and Attributes
+        self.assertIsInstance(attribute_data.values, omf_python.IndexArray)
+        self.assertIsInstance(attribute_data.names, omf_python.NameArray)
+        self.assertIsInstance(attribute_data.gradient, omf_python.GradientArray)
+        self.assertIsInstance(attribute_data.attributes[0], omf_python.Attribute)
+
+    def test_should_return_category_values(self) -> None:
+        # Given I have the category attribute data
+        attribute_data = self.reader.project.elements[1].attributes[0].get_data()
+
+        # When I read the values for the category
+        values = self.reader.array_indices(attribute_data.values)
+
+        # Then I should get the expected results
+        expected_values = [0, 0, 0, 0, 1]
+        self.assertEqual(values, expected_values)
+
+        # And when I read the names
+        names = self.reader.array_names(attribute_data.names)
+
+        # Then I should get the expected names back
+        expected_names = ["Base", "Top"]
+        self.assertEqual(names, expected_names)
+
+        # And when I read the gradient
+        gradient = self.reader.array_gradient(attribute_data.gradient)
+
+        expected_gradient = [[255, 128, 0, 255], [0, 128, 255, 255]]
+        self.assertEqual(gradient, expected_gradient)
+
+        # And when I get the category sub-attributes
+        category_attributes = attribute_data.attributes
+
+        # There should be one attribute
+        self.assertEqual(len(category_attributes), 1)
+        self.assertIsInstance(category_attributes[0], omf_python.Attribute)


### PR DESCRIPTION
This finishes the implementation of the `AttributeData::Category` variant, the test covers:

- `names` as a `NameArray`
- `values` as an `IndexArray`
- `gradient` as an `GradientArray`
- sub-`attributes` as a List of `Attribute`s