### PR TITLE
Change various getters to methods and fill in missing documentation

### DIFF
--- a/omf-python/src/array.rs
+++ b/omf-python/src/array.rs
@@ -4,6 +4,7 @@ use pyo3_stub_gen::derive::*;
 
 #[gen_stub_pyclass]
 #[pyclass(name = "VertexArray")]
+/// Vertex locations in 3D.
 pub struct PyVertexArray(pub Array<array_type::Vertex>);
 
 #[gen_stub_pymethods]
@@ -17,6 +18,7 @@ impl PyVertexArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "SegmentArray")]
+/// Line segments as indices into a vertex array.
 pub struct PySegmentArray(pub Array<array_type::Segment>);
 
 #[gen_stub_pymethods]
@@ -30,6 +32,7 @@ impl PySegmentArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "IndexArray")]
+/// Nullable category index values.
 pub struct PyIndexArray(pub Array<array_type::Index>);
 
 #[gen_stub_pymethods]
@@ -43,6 +46,7 @@ impl PyIndexArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "TriangleArray")]
+/// Triangles as indices into a vertex array.
 pub struct PyTriangleArray(pub Array<array_type::Triangle>);
 
 #[gen_stub_pymethods]
@@ -56,6 +60,7 @@ impl PyTriangleArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "ColorArray")]
+/// Nullable colors.
 pub struct PyColorArray(pub Array<array_type::Color>);
 
 #[gen_stub_pymethods]
@@ -69,6 +74,7 @@ impl PyColorArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "NameArray")]
+/// Non-nullable category names.
 pub struct PyNameArray(pub Array<array_type::Name>);
 
 #[gen_stub_pymethods]
@@ -82,7 +88,9 @@ impl PyNameArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "GradientArray")]
+/// Non-nullable colormap or category colors.
 pub struct PyGradientArray(pub Array<array_type::Gradient>);
+
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyGradientArray {
@@ -94,6 +102,7 @@ impl PyGradientArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "ImageArray")]
+/// An image in PNG or JPEG encoding.
 pub struct PyImageArray(pub Array<array_type::Image>);
 
 #[pymethods]
@@ -107,6 +116,7 @@ impl PyImageArray {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "TextureCoordinatesArray")]
+/// UV texture coordinates.
 pub struct PyTextureCoordinatesArray(pub Array<array_type::Texcoord>);
 
 #[gen_stub_pymethods]

--- a/omf-python/src/element.rs
+++ b/omf-python/src/element.rs
@@ -22,7 +22,6 @@ impl PyElement {
         self.0.description.clone()
     }
 
-    #[getter]
     fn attributes(&self) -> Vec<PyAttribute> {
         self.0
             .attributes

--- a/omf-python/src/element.rs
+++ b/omf-python/src/element.rs
@@ -1,7 +1,9 @@
 use crate::attribute::PyAttribute;
-use crate::geometry::PyGeometry;
+use crate::geometry::{PyLineSet, PyPointSet, PySurface};
 use omf::Color;
 use omf::Element;
+use omf::Geometry;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 
@@ -37,10 +39,14 @@ impl PyElement {
             .collect()
     }
 
-    #[getter]
     /// The geometry of the element.
-    fn geometry(&self) -> PyGeometry {
-        PyGeometry(self.0.geometry.clone())
+    fn geometry(&self, py: Python<'_>) -> PyResult<PyObject> {
+        match &self.0.geometry {
+            Geometry::PointSet(point_set) => Ok(PyPointSet(point_set.clone()).into_py(py)),
+            Geometry::LineSet(line_set) => Ok(PyLineSet(line_set.clone()).into_py(py)),
+            Geometry::Surface(surface) => Ok(PySurface(surface.clone()).into_py(py)),
+            _ => Err(PyValueError::new_err("Geometry type not supported")),
+        }
     }
 
     #[getter]

--- a/omf-python/src/element.rs
+++ b/omf-python/src/element.rs
@@ -36,51 +36,7 @@ impl PyElement {
     }
 
     #[getter]
-    fn color(&self) -> Option<PyColor> {
-        self.0.color.map(PyColor)
-    }
-}
-
-#[gen_stub_pyclass]
-#[pyclass(name = "Color")]
-pub struct PyColor(pub Color);
-
-#[gen_stub_pymethods]
-#[pymethods]
-impl PyColor {
-    const RED: usize = 0;
-    const GREEN: usize = 1;
-    const BLUE: usize = 2;
-    const ALPHA: usize = 3;
-
-    #[new]
-    pub fn new(red: u8, green: u8, blue: u8, alpha: u8) -> Self {
-        PyColor([red, green, blue, alpha])
-    }
-
-    fn __eq__(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-
-    #[getter]
-    fn red(&self) -> u8 {
-        self.0[Self::RED]
-    }
-
-    #[getter]
-    fn green(&self) -> u8 {
-        self.0[Self::GREEN]
-    }
-    #[getter]
-    fn blue(&self) -> u8 {
-        self.0[Self::BLUE]
-    }
-    #[getter]
-    fn alpha(&self) -> u8 {
-        self.0[Self::ALPHA]
-    }
-
-    fn as_list(&self) -> [u8; 4] {
-        self.0
+    fn color(&self) -> Option<Color> {
+        self.0.color
     }
 }

--- a/omf-python/src/element.rs
+++ b/omf-python/src/element.rs
@@ -7,21 +7,28 @@ use pyo3_stub_gen::derive::*;
 
 #[gen_stub_pyclass]
 #[pyclass(name = "Element")]
+/// Defines a single “object” or “shape” within the OMF file.
+///
+/// Each shape has a name plus other optional metadata, a “geometry” that describes a point-set, surface, etc.,
+/// and a list of attributes that that exist on that geometry.
 pub struct PyElement(pub Element);
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyElement {
     #[getter]
+    /// The element name. Names should be non-empty and unique.
     fn name(&self) -> String {
         self.0.name.clone()
     }
 
     #[getter]
+    /// Optional element description.
     fn description(&self) -> String {
         self.0.description.clone()
     }
 
+    /// List of attributes, if any.
     fn attributes(&self) -> Vec<PyAttribute> {
         self.0
             .attributes
@@ -31,11 +38,13 @@ impl PyElement {
     }
 
     #[getter]
+    /// The geometry of the element.
     fn geometry(&self) -> PyGeometry {
         PyGeometry(self.0.geometry.clone())
     }
 
     #[getter]
+    /// Optional solid color.
     fn color(&self) -> Option<Color> {
         self.0.color
     }

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -3,10 +3,10 @@ use crate::array::{
     PyNumberArray, PySegmentArray, PyTextArray, PyTextureCoordinatesArray, PyTriangleArray,
     PyVectorArray, PyVertexArray,
 };
-use crate::element::PyColor;
 use crate::validate::PyProblem;
 use crate::PyProject;
 use omf::file::{Limits, Reader};
+use omf::Color;
 use pyo3::types::PyBytes;
 use std::fs::File;
 
@@ -110,11 +110,10 @@ impl PyReader {
     }
 
     /// Read a Color array.
-    pub fn array_color(&self, array: &PyColorArray) -> PyResult<Vec<Option<PyColor>>> {
+    pub fn array_color(&self, array: &PyColorArray) -> PyResult<Vec<Option<Color>>> {
         self.0
             .array_colors(&array.0)
             .map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?
-            .map(|r| r.map(|c| c.map(PyColor)))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
     }

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -45,16 +45,65 @@ impl PyLimits {
 
 #[gen_stub_pyclass]
 #[pyclass(name = "Reader")]
+/// OMF reader object.
+///
+/// Typical usage pattern is:
+///
+/// - Create the reader object.
+/// - Optional: retrieve the file version with `reader.version()`.
+/// - Optional: adjust the limits with `reader.set_limits(...)`.
+/// - Read the project from the file with `reader.project()`.
+/// - Iterate through the project's contents to find the elements and attributes you want to load.
+/// - For each of those items load the array or image data.
+///
+/// **Warning:**
+///     When loading arrays and images from OMF files, beware of "zip bombs"
+///     where data is maliciously crafted to expand to an excessive size when decompressed,
+///     leading to a potential denial of service attack.
+///     Use the limits provided check arrays sizes before allocating memory.
 pub struct PyReader(Reader);
-
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyReader {
     #[new]
+    /// Creates a reader from an OMF file path.
+
+    /// Makes only the minimum number of reads to check the file header and footer.
+    /// Fails with an error if an IO error occurs or the file isn’t in OMF 2 format.
     pub fn new(filepath: &str) -> PyResult<Self> {
         let file = File::open(filepath).map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?;
         let reader = Reader::new(file).map_err(|e| PyErr::new::<PyIOError, _>(e.to_string()))?;
         Ok(PyReader(reader))
+    }
+
+    /// Returns the current limits.
+    fn limits(&self) -> PyResult<PyLimits> {
+        let limits = self.0.limits();
+        Ok(PyLimits {
+            json_bytes: limits.json_bytes,
+            image_bytes: limits.image_bytes,
+            image_dim: limits.image_dim,
+            validation: limits.validation,
+        })
+    }
+
+    /// Sets the memory limits.
+    ///
+    /// These limits prevent the reader from consuming excessive system resources, which might
+    /// allow denial of service attacks with maliciously crafted files. Running without limits
+    /// is not recommended.
+    fn set_limits(&mut self, limits: &PyLimits) {
+        self.0.set_limits(Limits {
+            json_bytes: limits.json_bytes,
+            image_bytes: limits.image_bytes,
+            image_dim: limits.image_dim,
+            validation: limits.validation,
+        });
+    }
+
+    /// Return the version number of the file, which can only be [2, 0] right now.
+    pub fn version(&self) -> [u32; 2] {
+        self.0.version()
     }
 
     /// Reads, validates, and returns the root `Project` object from the file.

--- a/omf-python/src/geometry.rs
+++ b/omf-python/src/geometry.rs
@@ -1,48 +1,17 @@
 //use omf::data::Vertices;
 
 use crate::array::{PySegmentArray, PyTriangleArray, PyVertexArray};
-use omf::{Geometry, LineSet, PointSet, Surface};
+use omf::{LineSet, PointSet, Surface};
 
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 
 #[gen_stub_pyclass]
-#[pyclass(name = "Geometry")]
-pub struct PyGeometry(pub Geometry);
+#[pyclass(name = "PointSet")]
+/// Point set geometry.
+pub struct PyPointSet(pub PointSet);
 
 #[gen_stub_pymethods]
-#[pymethods]
-impl PyGeometry {
-    fn type_name(&self) -> String {
-        //self.0.type_name().clone()
-        match &self.0 {
-            Geometry::PointSet(_) => "PointSet".to_string(),
-            Geometry::LineSet(_) => "LineSet".to_string(),
-            Geometry::Surface(_) => "Surface".to_string(),
-            Geometry::GridSurface(_) => "GridSurface".to_string(),
-            Geometry::Composite(_) => "Composite".to_string(),
-            Geometry::BlockModel(b) if b.has_subblocks() => "BlockModel(sub-blocked)".to_string(),
-            Geometry::BlockModel(_) => "BlockModel".to_string(),
-        }
-    }
-
-    fn get_object(&self, py: Python<'_>) -> PyResult<PyObject> {
-        match &self.0 {
-            Geometry::PointSet(point_set) => Ok(PyPointSet(point_set.clone()).into_py(py)),
-            Geometry::LineSet(line_set) => Ok(PyLineSet(line_set.clone()).into_py(py)),
-            Geometry::Surface(surface) => Ok(PySurface(surface.clone()).into_py(py)),
-            _ => Err(PyValueError::new_err(format!(
-                "Geometry {} is not supported",
-                self.type_name()
-            ))),
-        }
-    }
-}
-
-#[pyclass(name = "PointSet")]
-pub struct PyPointSet(PointSet);
-
 #[pymethods]
 impl PyPointSet {
     #[getter]
@@ -56,9 +25,12 @@ impl PyPointSet {
     }
 }
 
+#[gen_stub_pyclass]
 #[pyclass(name = "LineSet")]
-pub struct PyLineSet(LineSet);
+/// A set of line segments.
+pub struct PyLineSet(pub LineSet);
 
+#[gen_stub_pymethods]
 #[pymethods]
 impl PyLineSet {
     #[getter]
@@ -77,9 +49,12 @@ impl PyLineSet {
     }
 }
 
+#[gen_stub_pyclass]
 #[pyclass(name = "Surface")]
-pub struct PySurface(Surface);
+/// A surface made up of triangles.
+pub struct PySurface(pub Surface);
 
+#[gen_stub_pymethods]
 #[pymethods]
 impl PySurface {
     #[getter]

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -24,7 +24,7 @@ use attribute::{
 };
 use element::PyElement;
 use file::reader::{PyLimits, PyReader};
-use geometry::{PyGeometry, PyLineSet, PyPointSet, PySurface};
+use geometry::{PyLineSet, PyPointSet, PySurface};
 use omf1::converter::{detect_omf1, PyOmf1Converter};
 use project::PyProject;
 
@@ -59,7 +59,6 @@ fn omf_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTriangleArray>()?;
     m.add_class::<PyNameArray>()?;
     m.add_class::<PyElement>()?;
-    m.add_class::<PyGeometry>()?;
     m.add_class::<PyPointSet>()?;
     m.add_class::<PyLineSet>()?;
     m.add_class::<PyProject>()?;

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -22,7 +22,7 @@ use attribute::{
     PyAttributeDataMappedTexture, PyAttributeDataNumber, PyAttributeDataText,
     PyAttributeDataVector,
 };
-use element::{PyColor, PyElement};
+use element::PyElement;
 use file::reader::{PyLimits, PyReader};
 use geometry::{PyGeometry, PyLineSet, PyPointSet, PySurface};
 use omf1::converter::{detect_omf1, PyOmf1Converter};
@@ -46,7 +46,6 @@ fn omf_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAttributeDataNumber>()?;
     m.add_class::<PyAttributeDataText>()?;
     m.add_class::<PyAttributeDataVector>()?;
-    m.add_class::<PyColor>()?;
     m.add_class::<PyBooleanArray>()?;
     m.add_class::<PyColorArray>()?;
     m.add_class::<PyImageArray>()?;

--- a/omf-python/src/project.rs
+++ b/omf-python/src/project.rs
@@ -45,7 +45,6 @@ impl PyProject {
         self.0.application.clone()
     }
 
-    #[getter]
     fn elements(&self) -> Vec<PyElement> {
         self.0
             .elements

--- a/omf-python/src/project.rs
+++ b/omf-python/src/project.rs
@@ -5,46 +5,64 @@ use pyo3_stub_gen::derive::*;
 
 #[gen_stub_pyclass]
 #[pyclass(name = "Project")]
+/// This is the root element of an OMF file, holding global metadata and a list of Elements that describe the objects or
+/// shapes within the file.
 pub struct PyProject(pub Project);
 
 #[gen_stub_pymethods]
 #[pymethods]
 impl PyProject {
     #[getter]
+    /// Project name.
     fn name(&self) -> String {
         self.0.name.clone()
     }
 
     #[getter]
+    /// Optional project description.
     fn description(&self) -> String {
         self.0.description.clone()
     }
 
     #[getter]
+    /// Optional EPSG or PROJ local transformation string, default empty.
+    ///
+    /// Exactly what is supported depends on the application reading the file.
     fn coordinate_reference_system(&self) -> String {
         self.0.coordinate_reference_system.clone()
     }
 
     #[getter]
+    /// Optional unit for distances and locations within the file.
+    ///
+    /// Typically “meters”, “metres”, “feet”, or empty because the coordinate reference system defines it.
+    /// If both are empty then applications may assume meters.
     fn units(&self) -> String {
         self.0.units.clone()
     }
 
     #[getter]
+    /// Optional project origin, default [0, 0, 0].
+    ///
+    /// Most geometries also have their own origin field. To get the real location add this origin and the geometry origin
+    /// to all locations within each element.
     fn origin(&self) -> [f64; 3] {
         self.0.origin
     }
 
     #[getter]
+    /// Optional name or email address of the person that created the file, default empty.
     fn author(&self) -> String {
         self.0.author.clone()
     }
 
     #[getter]
+    /// Optional name and version of the application that created the file, default empty.
     fn application(&self) -> String {
         self.0.application.clone()
     }
 
+    /// List of elements.
     fn elements(&self) -> Vec<PyElement> {
         self.0
             .elements

--- a/omf-python/tests/test_boolean_attribute.py
+++ b/omf-python/tests/test_boolean_attribute.py
@@ -10,7 +10,7 @@ class TestBooleanAttribute(TestCase):
         self.project, _ = self.reader.project()
 
         # Get the "Regular block model" element, and its "Filter" attribute.
-        self.attribute = self.project.elements[4].attributes[0]
+        self.attribute = self.project.elements()[4].attributes()[0]
 
     def test_should_return_boolean_attribute_instance(self) -> None:
         self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataBoolean)

--- a/omf-python/tests/test_category_attribute.py
+++ b/omf-python/tests/test_category_attribute.py
@@ -9,36 +9,28 @@ class TestCategoryAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.attribute = self.project.elements()[1].attributes()[0]
 
     def test_should_return_category_attribute_details(self) -> None:
-        attributes = self.project.elements[1].attributes
+        self.assertIsInstance(self.attribute, omf_python.Attribute)
 
-        self.assertEqual(len(attributes), 3)
+        self.assertEqual(self.attribute.name, "Categories")
 
-        for attribute in attributes:
-            self.assertIsInstance(attribute, omf_python.Attribute)
+        self.assertEqual(self.attribute.description, "Divides the points into top and base.")
 
-        attribute = attributes[0]
+        self.assertEqual(self.attribute.units, "whatever")
 
-        self.assertEqual(attribute.name, "Categories")
-
-        self.assertEqual(attribute.description, "Divides the points into top and base.")
-
-        self.assertEqual(attribute.units, "whatever")
-
-        metadata_string = attribute.metadata
+        metadata_string = self.attribute.metadata
         metadata = json.loads(metadata_string)
         expected_metadata = {
             "key": "value"
         }
         self.assertEqual(metadata, expected_metadata)
 
-        self.assertEqual(attribute.location, "Vertices")
+        self.assertEqual(self.attribute.location, "Vertices")
 
     def test_should_return_category_attribute_array_instances(self) -> None:
-        attributes = self.project.elements[1].attributes
-
-        attribute_data = attributes[0].get_data()
+        attribute_data = self.attribute.get_data()
 
         self.assertIsInstance(attribute_data, omf_python.AttributeDataCategory)
 
@@ -48,7 +40,7 @@ class TestCategoryAttribute(TestCase):
         self.assertIsInstance(attribute_data.attributes[0], omf_python.Attribute)
 
     def test_should_return_category_attribute_expected_values(self) -> None:
-        attribute_data = self.project.elements[1].attributes[0].get_data()
+        attribute_data = self.attribute.get_data()
 
         values = self.reader.array_indices(attribute_data.values)
 

--- a/omf-python/tests/test_color_attribute.py
+++ b/omf-python/tests/test_color_attribute.py
@@ -9,15 +9,10 @@ class TestColorAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.attribute = self.project.elements()[0].attributes()[1]
 
     def test_should_return_expected_color_attributes(self) -> None:
-        attributes = self.project.elements[0].attributes
-        self.assertEqual(3, len(attributes))
-
-        color_attributes = [a for a in attributes if a.name == "Colors"]
-        self.assertEqual(1, len(color_attributes))
-
-        values = color_attributes[0].get_data().values
+        values = self.attribute.get_data().values
         self.assertEqual(6, values.item_count)
 
         color_array = self.reader.array_color(values)

--- a/omf-python/tests/test_color_attribute.py
+++ b/omf-python/tests/test_color_attribute.py
@@ -17,12 +17,12 @@ class TestColorAttribute(TestCase):
 
         color_array = self.reader.array_color(values)
         self.assertEqual(6, len(color_array))
-        COLORS = [
-            omf_python.Color(255, 0, 0, 255),
-            omf_python.Color(255, 255, 0, 255),
-            omf_python.Color(0, 255, 0, 255),
-            omf_python.Color(0, 0, 255, 255),
-            omf_python.Color(255, 255, 255, 255),
-            omf_python.Color(255, 255, 255, 255),
+        expected_colors = [
+            [255, 0, 0, 255],
+            [255, 255, 0, 255],
+            [0, 255, 0, 255],
+            [0, 0, 255, 255],
+            [255, 255, 255, 255],
+            [255, 255, 255, 255],
         ]
-        self.assertEqual(COLORS, color_array)
+        self.assertEqual(expected_colors, color_array)

--- a/omf-python/tests/test_geometry_surface.py
+++ b/omf-python/tests/test_geometry_surface.py
@@ -69,8 +69,4 @@ class TestGeometrySurface(TestCase):
         self.assertIsInstance(surface, omf_python.Surface)
 
         # And it has the correct color
-        color = surfaces[0].color
-        self.assertEqual(255, color.red)
-        self.assertEqual(255, color.green)
-        self.assertEqual(0, color.blue)
-        self.assertEqual(255, color.alpha)
+        self.assertEqual([255,255,0,255], surfaces[0].color)

--- a/omf-python/tests/test_geometry_surface.py
+++ b/omf-python/tests/test_geometry_surface.py
@@ -17,7 +17,7 @@ class TestGeometrySurface(TestCase):
 
         # Then there is one surface element
         surfaces = [
-            s for s in project.elements if s.geometry.type_name() == "Surface"
+            s for s in project.elements() if s.geometry.type_name() == "Surface"
         ]
         self.assertEqual(1, len(surfaces))
 
@@ -60,7 +60,7 @@ class TestGeometrySurface(TestCase):
 
         # Then there is one surface element
         surfaces = [
-            s for s in project.elements if s.geometry.type_name() == "Surface"
+            s for s in project.elements() if s.geometry.type_name() == "Surface"
         ]
         self.assertEqual(1, len(surfaces))
 

--- a/omf-python/tests/test_geometry_surface.py
+++ b/omf-python/tests/test_geometry_surface.py
@@ -15,14 +15,8 @@ class TestGeometrySurface(TestCase):
         reader = omf_python.Reader(omf_file)
         project, _ = reader.project()
 
-        # Then there is one surface element
-        surfaces = [
-            s for s in project.elements() if s.geometry.type_name() == "Surface"
-        ]
-        self.assertEqual(1, len(surfaces))
-
-        # And it has the correct type of omf_python.Surface
-        surface = surfaces[0].geometry.get_object()
+        # Geometry is an instance of omf_python.Surface
+        surface = project.elements()[0].geometry()
         self.assertIsInstance(surface, omf_python.Surface)
 
         # And it contains 6 triangles
@@ -51,22 +45,14 @@ class TestGeometrySurface(TestCase):
         self.assertEqual(TRIANGLES, triangles)
 
     def test_should_contain_color(self) -> None:
-        # Given the pyramid sample omf file
+        # Given
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
 
         # When
         reader = omf_python.Reader(omf_file)
         project, _ = reader.project()
 
-        # Then there is one surface element
-        surfaces = [
-            s for s in project.elements() if s.geometry.type_name() == "Surface"
-        ]
-        self.assertEqual(1, len(surfaces))
+        surface = project.elements()[0]
 
-        # And it has the correct type of omf_python.Surface
-        surface = surfaces[0].geometry.get_object()
-        self.assertIsInstance(surface, omf_python.Surface)
-
-        # And it has the correct color
-        self.assertEqual([255,255,0,255], surfaces[0].color)
+        # Then
+        self.assertEqual([255,255,0,255], surface.color)

--- a/omf-python/tests/test_lineset.py
+++ b/omf-python/tests/test_lineset.py
@@ -12,18 +12,15 @@ class TestLineSet(TestCase):
         self.lineset = self.project.elements()[2]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        lineset_type = self.lineset.geometry.type_name()
-
-        self.assertEqual(lineset_type, "LineSet")
+        self.assertIsInstance(self.lineset.geometry(), omf_python.LineSet)
 
     def test_should_return_expected_origin(self) -> None:
-        lineset_origin = self.lineset.geometry.get_object().origin
-
+        lineset_origin = self.lineset.geometry().origin
         self.assertEqual(lineset_origin, [0.0, 0.0, 0.0])
 
     def test_should_return_expected_vertices(self) -> None:
         # Given
-        vertices_array = self.lineset.geometry.get_object().vertices
+        vertices_array = self.lineset.geometry().vertices
 
         # When
         vertices = self.reader.array_vertices(vertices_array)
@@ -40,7 +37,7 @@ class TestLineSet(TestCase):
 
     def test_should_return_expected_segments(self) -> None:
         # Given
-        segments_array = self.lineset.geometry.get_object().segments
+        segments_array = self.lineset.geometry().segments
 
         # When
         segments = self.reader.array_segments(segments_array)

--- a/omf-python/tests/test_lineset.py
+++ b/omf-python/tests/test_lineset.py
@@ -9,20 +9,21 @@ class TestLineSet(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.lineset = self.project.elements()[2]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        lineset_type = self.project.elements[2].geometry.type_name()
+        lineset_type = self.lineset.geometry.type_name()
 
         self.assertEqual(lineset_type, "LineSet")
 
     def test_should_return_expected_origin(self) -> None:
-        lineset_origin = self.project.elements[2].geometry.get_object().origin
+        lineset_origin = self.lineset.geometry.get_object().origin
 
         self.assertEqual(lineset_origin, [0.0, 0.0, 0.0])
 
     def test_should_return_expected_vertices(self) -> None:
         # Given
-        vertices_array = self.project.elements[2].geometry.get_object().vertices
+        vertices_array = self.lineset.geometry.get_object().vertices
 
         # When
         vertices = self.reader.array_vertices(vertices_array)
@@ -39,7 +40,7 @@ class TestLineSet(TestCase):
 
     def test_should_return_expected_segments(self) -> None:
         # Given
-        segments_array = self.project.elements[2].geometry.get_object().segments
+        segments_array = self.lineset.geometry.get_object().segments
 
         # When
         segments = self.reader.array_segments(segments_array)

--- a/omf-python/tests/test_mapped_texture_attibute.py
+++ b/omf-python/tests/test_mapped_texture_attibute.py
@@ -9,22 +9,15 @@ class TestMappedTextureAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
-        
+        self.attribute = self.project.elements()[9].attributes()[1]
+
         test_png = path.join(omf_dir, "test.png")
         with open(test_png, "rb") as file:
             self.image = file.read()
 
     def test_should_return_expected_texture_attributes(self) -> None:
-        # Given an element with a MappedTexture attribute
-        attributes = self.project.elements[9].attributes
-        self.assertEqual(2, len(attributes))
-
-        # Then should be able to get the MappedTexture attribute
-        texture_attributes = [a for a in attributes if a.name == "Mapped"]
-        self.assertEqual(1, len(texture_attributes))
-
         # And it should have texture coordinates
-        texcoords = texture_attributes[0].get_data().texcoords
+        texcoords = self.attribute.get_data().texcoords
 
         # And those coordinates should match the expected value
         self.assertEqual(4, texcoords.item_count)
@@ -34,7 +27,7 @@ class TestMappedTextureAttribute(TestCase):
         self.assertEqual(COORDINATES, coordinates)
 
         # And it should contain an image
-        image = texture_attributes[0].get_data().image
+        image = self.attribute.get_data().image
         # Images always have an item count of zero
         self.assertEqual(0, image.item_count)
 

--- a/omf-python/tests/test_number_attribute.py
+++ b/omf-python/tests/test_number_attribute.py
@@ -8,14 +8,13 @@ class TestNumberAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.attribute = self.project.elements()[0].attributes()[2]
 
     def test_should_return_number_attribute_instance(self) -> None:
-        attribute = self.project.elements[0].attributes[2]
-
-        self.assertIsInstance(attribute.get_data(), omf_python.AttributeDataNumber)
+        self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataNumber)
 
     def test_should_return_number_attribute_values(self) -> None:
-        attribute_data = self.project.elements[0].attributes[2].get_data()
+        attribute_data = self.attribute.get_data()
 
         expected_values = [946684800.0, 946688400.0, 946692000.0, 946695600.0, 946699200.0]
         actual_values = self.reader.array_numbers(attribute_data.values)

--- a/omf-python/tests/test_omf1_converter.py
+++ b/omf-python/tests/test_omf1_converter.py
@@ -22,7 +22,7 @@ class TestOmf1Converter(TestCase):
             # Then
             reader = omf_python.Reader(omf2_file.name)
             project, _ = reader.project()
-            self.assertEqual(len(project.elements), 2)
+            self.assertEqual(len(project.elements()), 2)
 
     def test_should_return_expected_problems(self) -> None:
         # Given

--- a/omf-python/tests/test_pointset.py
+++ b/omf-python/tests/test_pointset.py
@@ -11,17 +11,15 @@ class TestPointSet(TestCase):
         self.pointset = self.project.elements()[1]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        pointset_type = self.pointset.geometry.type_name()
-        self.assertEqual(pointset_type, "PointSet")
+        self.assertIsInstance(self.pointset.geometry(), omf_python.PointSet)
 
     def test_should_return_expected_origin(self) -> None:
-        pointset_origin = self.pointset.geometry.get_object().origin
-
+        pointset_origin = self.pointset.geometry().origin
         self.assertEqual(pointset_origin, [0.0, 0.0, 0.0])
 
     def test_should_return_expected_vertices(self) -> None:
         # Given
-        vertices_array = self.pointset.geometry.get_object().vertices
+        vertices_array = self.pointset.geometry().vertices
 
         # When
         vertices = self.reader.array_vertices(vertices_array)

--- a/omf-python/tests/test_pointset.py
+++ b/omf-python/tests/test_pointset.py
@@ -8,20 +8,20 @@ class TestPointSet(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.pointset = self.project.elements()[1]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        pointset_type = self.project.elements[1].geometry.type_name()
-
+        pointset_type = self.pointset.geometry.type_name()
         self.assertEqual(pointset_type, "PointSet")
 
     def test_should_return_expected_origin(self) -> None:
-        pointset_origin = self.project.elements[1].geometry.get_object().origin
+        pointset_origin = self.pointset.geometry.get_object().origin
 
         self.assertEqual(pointset_origin, [0.0, 0.0, 0.0])
 
     def test_should_return_expected_vertices(self) -> None:
         # Given
-        vertices_array = self.project.elements[1].geometry.get_object().vertices
+        vertices_array = self.pointset.geometry.get_object().vertices
 
         # When
         vertices = self.reader.array_vertices(vertices_array)

--- a/omf-python/tests/test_project.py
+++ b/omf-python/tests/test_project.py
@@ -27,7 +27,7 @@ class TestProject(TestCase):
         project, _ = self.reader.project()
 
         # When I get the elements
-        elements = project.elements
+        elements = project.elements()
 
         # Then I should have two elements
         self.assertEqual(len(elements), 2)

--- a/omf-python/tests/test_projected_texture_attribute.py
+++ b/omf-python/tests/test_projected_texture_attribute.py
@@ -9,16 +9,16 @@ class TestProjectedTextureAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.attribute = self.project.elements()[9].attributes()[0]
 
         test_png = path.join(omf_dir, "test.png")
         with open(test_png, "rb") as file:
             self.image = file.read()
 
     def test_should_return_expected_projected_texture_attribute(self) -> None:
-        projected_texture_attribute = self.project.elements[9].attributes[0]
-        self.assertEqual("Projected", projected_texture_attribute.name)
+        self.assertEqual("Projected", self.attribute.name)
 
-        attribute_data = projected_texture_attribute.get_data()
+        attribute_data = self.attribute.get_data()
 
         self.assertEqual(1.0, attribute_data.width)
         self.assertEqual(1.0, attribute_data.height)

--- a/omf-python/tests/test_text_attribute.py
+++ b/omf-python/tests/test_text_attribute.py
@@ -10,7 +10,7 @@ class TestTextAttribute(TestCase):
         self.project, _ = self.reader.project()
 
         # Get the "Pyramid Lines" element, and its "Strings" attribute.
-        self.attribute = self.project.elements[2].attributes[0]
+        self.attribute = self.project.elements()[2].attributes()[0]
 
     def test_should_return_text_attribute_instance(self) -> None:
         self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataText)

--- a/omf-python/tests/test_vector_attribute.py
+++ b/omf-python/tests/test_vector_attribute.py
@@ -8,14 +8,13 @@ class TestVectorAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         self.reader = omf_python.Reader(one_of_everything)
         self.project, _ = self.reader.project()
+        self.attribute = self.project.elements()[1].attributes()[1]
 
     def test_should_return_vector_attribute_instance(self) -> None:
-        attribute = self.project.elements[1].attributes[1]
-
-        self.assertIsInstance(attribute.get_data(), omf_python.AttributeDataVector)
+        self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataVector)
 
     def test_should_return_vector_attribute_values(self) -> None:
-        attribute_data = self.project.elements[1].attributes[1].get_data()
+        attribute_data = self.attribute.get_data()
 
         expected_values = [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0], None]
         actual_values = self.reader.array_vectors(attribute_data.values)


### PR DESCRIPTION
Change elements() and attributes() to a methods instead of getters. This makes it clearer that this is doing work each time it is called and it is not giving you access to the internal vectors directly.

Add missing version() and limits methods to Reader.

Make element.geometry() return the variant avoiding need for PyGeometry class.

Handle color the same way we handle other short vec attributes.
