### PR TITLE
Add python bindings Block Model geometry type

### DIFF
--- a/omf-python/Cargo.toml
+++ b/omf-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omf_python"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python bindings for the Rust OMF package."
 edition = "2021"
 license = "MIT"

--- a/omf-python/src/array.rs
+++ b/omf-python/src/array.rs
@@ -77,6 +77,16 @@ pub struct PyBooleanArray(pub Array<array_type::Boolean>);
 /// Discrete color-map boundaries.
 pub struct PyBoundaryArray(pub Array<array_type::Boundary>);
 
+#[gen_stub_pyclass]
+#[pyclass(name = "RegularSubblockArray")]
+/// Parent indices and corners of regular sub-blocks.
+pub struct PyRegularSubblockArray(pub Array<array_type::RegularSubblock>);
+
+#[gen_stub_pyclass]
+#[pyclass(name = "FreeformSubblockArray")]
+/// Parent indices and corners of free-form sub-blocks.
+pub struct PyFreeformSubblockArray(pub Array<array_type::FreeformSubblock>);
+
 macro_rules! array_type_impl {
     ($($arrayType:ty)*) => ($(
         #[gen_stub_pymethods]
@@ -106,4 +116,6 @@ array_type_impl! {
     PyTextArray
     PyBooleanArray
     PyBoundaryArray
+    PyRegularSubblockArray
+    PyFreeformSubblockArray
 }

--- a/omf-python/src/block_model.rs
+++ b/omf-python/src/block_model.rs
@@ -1,4 +1,4 @@
-use omf::BlockModel;
+use omf::{BlockModel, SubblockMode, Subblocks};
 
 use crate::{
     array::{PyFreeformSubblockArray, PyRegularSubblockArray},
@@ -7,6 +7,116 @@ use crate::{
 
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
+
+#[gen_stub_pyclass_enum]
+#[pyclass(eq, eq_int, name = "SubblockMode")]
+#[derive(PartialEq)]
+/// An optional mode for regular sub-blocks.
+pub enum PySubblockMode {
+    Octree,
+    Full,
+}
+
+#[gen_stub_pyclass]
+#[pyclass(name = "RegularSubblocks")]
+/// Block model geometry with optional sub-blocks.
+pub struct PyRegularSubblocks(pub Subblocks);
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyRegularSubblocks {
+    #[getter]
+    /// The sub-block grid size.
+    ///
+    /// Must be greater than zero in all directions. If `mode` is octree then these must also
+    /// be powers of two but they don't have to be equal.
+    fn count(&self) -> [u32; 3] {
+        match self.0 {
+            omf::Subblocks::Regular { count, .. } => count,
+            _ => unreachable!(),
+        }
+    }
+
+    #[getter]
+    /// If present this further restricts the sub-block layout.
+    fn mode(&self) -> Option<PySubblockMode> {
+        match &self.0 {
+            omf::Subblocks::Regular { mode, .. } => match mode {
+                Some(mode) => match mode {
+                    SubblockMode::Octree { .. } => Some(PySubblockMode::Octree),
+                    SubblockMode::Full { .. } => Some(PySubblockMode::Full),
+                },
+                None => None,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    #[getter]
+    /// Array storing the sub-block parent indices and corners
+    /// relative to the sub-block grid within the parent.
+    fn subblocks(&self) -> PyRegularSubblockArray {
+        match &self.0 {
+            omf::Subblocks::Regular { subblocks, .. } => PyRegularSubblockArray(subblocks.clone()),
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl TryFrom<Subblocks> for PyRegularSubblocks {
+    type Error = ();
+
+    fn try_from(value: Subblocks) -> Result<Self, Self::Error> {
+        match value {
+            Subblocks::Regular { .. } => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<PyRegularSubblocks> for Subblocks {
+    fn from(value: PyRegularSubblocks) -> Self {
+        value.0
+    }
+}
+
+#[gen_stub_pyclass]
+#[pyclass(name = "FreeformSubblocks")]
+/// Block model geometry with optional sub-blocks.
+pub struct PyFreeformSubblocks(pub Subblocks);
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyFreeformSubblocks {
+    #[getter]
+    /// Array storing the sub-block parent indices and corners
+    /// relative to the parent.
+    fn subblocks(&self) -> PyFreeformSubblockArray {
+        match &self.0 {
+            omf::Subblocks::Freeform { subblocks, .. } => {
+                PyFreeformSubblockArray(subblocks.clone())
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl TryFrom<Subblocks> for PyFreeformSubblocks {
+    type Error = ();
+
+    fn try_from(value: Subblocks) -> Result<Self, Self::Error> {
+        match value {
+            Subblocks::Freeform { .. } => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<PyFreeformSubblocks> for Subblocks {
+    fn from(value: PyFreeformSubblocks) -> Self {
+        value.0
+    }
+}
 
 #[gen_stub_pyclass]
 #[pyclass(name = "BlockModel")]
@@ -39,13 +149,17 @@ impl PyBlockModel {
     /// Optional sub-blocks, which can be regular or free-form divisions of the parent blocks.
     fn subblocks(&self, py: Python<'_>) -> Option<PyObject> {
         match &self.0.subblocks {
-            Some(_subblocks) => match _subblocks {
-                omf::Subblocks::Regular { subblocks, .. } => {
-                    Some(PyRegularSubblockArray(subblocks.clone()).into_py(py))
-                }
-                omf::Subblocks::Freeform { subblocks, .. } => {
-                    Some(PyFreeformSubblockArray(subblocks.clone()).into_py(py))
-                }
+            Some(subblocks) => match subblocks {
+                Subblocks::Regular { .. } => Some(
+                    PyRegularSubblocks::try_from(subblocks.clone())
+                        .expect("conversion from Subblocks::Regular should succeed")
+                        .into_py(py),
+                ),
+                Subblocks::Freeform { .. } => Some(
+                    PyFreeformSubblocks::try_from(subblocks.clone())
+                        .expect("conversion from Subblocks::Freeform should succeed")
+                        .into_py(py),
+                ),
             },
             None => None,
         }

--- a/omf-python/src/block_model.rs
+++ b/omf-python/src/block_model.rs
@@ -1,0 +1,53 @@
+use omf::BlockModel;
+
+use crate::{
+    array::{PyFreeformSubblockArray, PyRegularSubblockArray},
+    grid::{PyGrid3Regular, PyGrid3Tensor, PyOrient3},
+};
+
+use pyo3::prelude::*;
+use pyo3_stub_gen::derive::*;
+
+#[gen_stub_pyclass]
+#[pyclass(name = "BlockModel")]
+/// Block model geometry with optional sub-blocks.
+pub struct PyBlockModel(pub BlockModel);
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyBlockModel {
+    #[getter]
+    /// Orientation of the block model.
+    fn orient(&self) -> PyOrient3 {
+        PyOrient3(self.0.orient)
+    }
+
+    #[getter]
+    /// Block sizes.
+    fn grid(&self, py: Python<'_>) -> PyObject {
+        match self.0.grid {
+            omf::Grid3::Regular { .. } => PyGrid3Regular::try_from(self.0.grid.clone())
+                .expect("conversion from Grid3::Regular should succeed")
+                .into_py(py),
+            omf::Grid3::Tensor { .. } => PyGrid3Tensor::try_from(self.0.grid.clone())
+                .expect("conversion from Grid3::Tensor should succeed")
+                .into_py(py),
+        }
+    }
+
+    #[getter]
+    /// Optional sub-blocks, which can be regular or free-form divisions of the parent blocks.
+    fn subblocks(&self, py: Python<'_>) -> Option<PyObject> {
+        match &self.0.subblocks {
+            Some(_subblocks) => match _subblocks {
+                omf::Subblocks::Regular { subblocks, .. } => {
+                    Some(PyRegularSubblockArray(subblocks.clone()).into_py(py))
+                }
+                omf::Subblocks::Freeform { subblocks, .. } => {
+                    Some(PyFreeformSubblockArray(subblocks.clone()).into_py(py))
+                }
+            },
+            None => None,
+        }
+    }
+}

--- a/omf-python/src/element.rs
+++ b/omf-python/src/element.rs
@@ -1,4 +1,5 @@
 use crate::attribute::PyAttribute;
+use crate::block_model::PyBlockModel;
 use crate::errors::{OmfJsonException, OmfNotSupportedException};
 use crate::geometry::{PyGridSurface, PyLineSet, PyPointSet, PySurface};
 use omf::Color;
@@ -55,6 +56,7 @@ impl PyElement {
             Geometry::GridSurface(grid_surface) => {
                 Ok(PyGridSurface(grid_surface.clone()).into_py(py))
             }
+            Geometry::BlockModel(block_model) => Ok(PyBlockModel(block_model.clone()).into_py(py)),
             _ => Err(OmfNotSupportedException::new_err(
                 "Geometry type not supported",
             )),

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -1,7 +1,7 @@
 use crate::array::{
-    PyBooleanArray, PyBoundaryArray, PyColorArray, PyGradientArray, PyImageArray, PyIndexArray,
-    PyNameArray, PyNumberArray, PyScalarArray, PySegmentArray, PyTexcoordArray, PyTextArray,
-    PyTriangleArray, PyVectorArray, PyVertexArray,
+    PyBooleanArray, PyBoundaryArray, PyColorArray, PyFreeformSubblockArray, PyGradientArray,
+    PyImageArray, PyIndexArray, PyNameArray, PyNumberArray, PyRegularSubblockArray, PyScalarArray,
+    PySegmentArray, PyTexcoordArray, PyTextArray, PyTriangleArray, PyVectorArray, PyVertexArray,
 };
 use crate::errors::OmfException;
 use crate::validate::PyProblem;
@@ -273,5 +273,29 @@ impl PyReader {
                 _ => None,
             })
             .collect())
+    }
+
+    /// Read a RegularSubblock array.
+    pub fn array_regular_subblocks(
+        &self,
+        array: &PyRegularSubblockArray,
+    ) -> PyResult<Vec<([u32; 3], [u32; 6])>> {
+        self.0
+            .array_regular_subblocks(&array.0)
+            .map_err(OmfException::py_err)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(OmfException::py_err)
+    }
+
+    /// Read a FreeformSubblock array.
+    pub fn array_freeform_subblocks(
+        &self,
+        array: &PyFreeformSubblockArray,
+    ) -> PyResult<Vec<([u32; 3], [f64; 6])>> {
+        self.0
+            .array_freeform_subblocks(&array.0)
+            .map_err(OmfException::py_err)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(OmfException::py_err)
     }
 }

--- a/omf-python/src/geometry.rs
+++ b/omf-python/src/geometry.rs
@@ -93,10 +93,10 @@ impl PyGridSurface {
     fn grid(&self, py: Python<'_>) -> PyObject {
         match self.0.grid {
             omf::Grid2::Regular { .. } => PyGrid2Regular::try_from(self.0.grid.clone())
-                .expect("conversion from Regular should succeed")
+                .expect("conversion from Grid2::Regular should succeed")
                 .into_py(py),
             omf::Grid2::Tensor { .. } => PyGrid2Tensor::try_from(self.0.grid.clone())
-                .expect("conversion from Tensor should succeed")
+                .expect("conversion from Grid2::Tensor should succeed")
                 .into_py(py),
         }
     }

--- a/omf-python/src/grid.rs
+++ b/omf-python/src/grid.rs
@@ -1,11 +1,11 @@
-use omf::{Grid2, Orient2, Vector3};
+use omf::{Grid2, Grid3, Orient2, Orient3, Vector3};
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 
 use crate::array::PyScalarArray;
 
 #[gen_stub_pyclass]
-#[pyclass(name = "Regular")]
+#[pyclass(name = "Grid2Regular")]
 #[derive(Clone)]
 /// Regularly spaced cells.
 pub struct PyGrid2Regular(Grid2);
@@ -15,7 +15,6 @@ impl TryFrom<Grid2> for PyGrid2Regular {
 
     fn try_from(value: Grid2) -> Result<Self, Self::Error> {
         match value {
-            // A Regular grid can be converted to PyGrid2Regular.
             Grid2::Regular { .. } => Ok(Self(value)),
             _ => Err(()),
         }
@@ -57,7 +56,7 @@ impl PyGrid2Regular {
 }
 
 #[gen_stub_pyclass]
-#[pyclass(name = "Tensor")]
+#[pyclass(name = "Grid2Tensor")]
 #[derive(Clone)]
 /// Tensor cells, where each row and column can have a different size.
 pub struct PyGrid2Tensor(Grid2);
@@ -67,7 +66,6 @@ impl TryFrom<Grid2> for PyGrid2Tensor {
 
     fn try_from(value: Grid2) -> Result<Self, Self::Error> {
         match value {
-            // A Tensor grid can be converted to PyGrid2Tensor.
             Grid2::Tensor { .. } => Ok(Self(value)),
             _ => Err(()),
         }
@@ -116,6 +114,123 @@ impl PyGrid2Tensor {
 }
 
 #[gen_stub_pyclass]
+#[pyclass(name = "Grid3Regular")]
+#[derive(Clone)]
+/// Regularly spaced cells.
+pub struct PyGrid3Regular(Grid3);
+
+impl TryFrom<Grid3> for PyGrid3Regular {
+    type Error = ();
+
+    fn try_from(value: Grid3) -> Result<Self, Self::Error> {
+        match value {
+            Grid3::Regular { .. } => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<PyGrid3Regular> for Grid3 {
+    fn from(value: PyGrid3Regular) -> Self {
+        value.0
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyGrid3Regular {
+    #[getter]
+    /// The block size in the U and V axes.
+    fn size(&self) -> [f64; 3] {
+        match self.0 {
+            Grid3::Regular { size, .. } => size,
+            Grid3::Tensor { .. } => unreachable!(),
+        }
+    }
+
+    /// Returns the number of blocks in each axis.
+    fn count(&self) -> [u32; 3] {
+        self.0.count()
+    }
+
+    /// Returns the total number of blocks.
+    fn flat_count(&self) -> u64 {
+        self.0.flat_count()
+    }
+
+    /// Returns the total number of block corners.
+    fn flat_corner_count(&self) -> u64 {
+        self.0.flat_corner_count()
+    }
+}
+
+#[gen_stub_pyclass]
+#[pyclass(name = "Grid3Tensor")]
+#[derive(Clone)]
+/// Tensor cells, where each row, column and layer can have a different size.
+pub struct PyGrid3Tensor(Grid3);
+
+impl TryFrom<Grid3> for PyGrid3Tensor {
+    type Error = ();
+
+    fn try_from(value: Grid3) -> Result<Self, Self::Error> {
+        match value {
+            Grid3::Tensor { .. } => Ok(Self(value)),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<PyGrid3Tensor> for Grid3 {
+    fn from(value: PyGrid3Tensor) -> Self {
+        value.0
+    }
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyGrid3Tensor {
+    #[getter]
+    fn u(&self) -> PyScalarArray {
+        match &self.0 {
+            Grid3::Regular { .. } => unreachable!(),
+            Grid3::Tensor { u, .. } => PyScalarArray(u.clone()),
+        }
+    }
+
+    #[getter]
+    fn v(&self) -> PyScalarArray {
+        match &self.0 {
+            Grid3::Regular { .. } => unreachable!(),
+            Grid3::Tensor { v, .. } => PyScalarArray(v.clone()),
+        }
+    }
+
+    #[getter]
+    fn w(&self) -> PyScalarArray {
+        match &self.0 {
+            Grid3::Regular { .. } => unreachable!(),
+            Grid3::Tensor { w, .. } => PyScalarArray(w.clone()),
+        }
+    }
+
+    /// Returns the number of blocks in each axis.
+    fn count(&self) -> [u32; 3] {
+        self.0.count()
+    }
+
+    /// Returns the total number of blocks.
+    fn flat_count(&self) -> u64 {
+        self.0.flat_count()
+    }
+
+    /// Returns the total number of block corners.
+    fn flat_corner_count(&self) -> u64 {
+        self.0.flat_corner_count()
+    }
+}
+
+#[gen_stub_pyclass]
 #[pyclass(name = "Orient2")]
 /// Defines the position and orientation of a 2D plane in 3D space.
 pub struct PyOrient2(pub Orient2);
@@ -136,5 +251,34 @@ impl PyOrient2 {
     #[getter]
     fn v(&self) -> Vector3 {
         self.0.v
+    }
+}
+
+#[gen_stub_pyclass]
+#[pyclass(name = "Orient3")]
+/// Defines the position and orientation of a 3D sub-space.
+pub struct PyOrient3(pub Orient3);
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl PyOrient3 {
+    #[getter]
+    fn origin(&self) -> Vector3 {
+        self.0.origin
+    }
+
+    #[getter]
+    fn u(&self) -> Vector3 {
+        self.0.u
+    }
+
+    #[getter]
+    fn v(&self) -> Vector3 {
+        self.0.v
+    }
+
+    #[getter]
+    fn w(&self) -> Vector3 {
+        self.0.w
     }
 }

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -1,10 +1,12 @@
-use grid::{PyGrid2Regular, PyGrid2Tensor, PyOrient2};
+use block_model::PyBlockModel;
+use grid::{PyGrid2Regular, PyGrid2Tensor, PyGrid3Regular, PyGrid3Tensor, PyOrient2, PyOrient3};
 /// Python bindings.
 use pyo3::prelude::*;
 use pyo3_stub_gen::{define_stub_info_gatherer, derive::*};
 
 mod array;
 mod attribute;
+mod block_model;
 mod colormap;
 mod element;
 mod errors;
@@ -16,9 +18,9 @@ mod project;
 mod validate;
 
 use array::{
-    PyBooleanArray, PyBoundaryArray, PyColorArray, PyGradientArray, PyImageArray, PyIndexArray,
-    PyNameArray, PyNumberArray, PyScalarArray, PySegmentArray, PyTexcoordArray, PyTextArray,
-    PyTriangleArray, PyVectorArray, PyVertexArray,
+    PyBooleanArray, PyBoundaryArray, PyColorArray, PyFreeformSubblockArray, PyGradientArray,
+    PyImageArray, PyIndexArray, PyNameArray, PyNumberArray, PyRegularSubblockArray, PyScalarArray,
+    PySegmentArray, PyTexcoordArray, PyTextArray, PyTriangleArray, PyVectorArray, PyVertexArray,
 };
 use attribute::{
     PyAttribute, PyAttributeDataBoolean, PyAttributeDataCategory, PyAttributeDataColor,
@@ -73,11 +75,17 @@ fn omf_python(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyVertexArray>()?;
     m.add_class::<PyTexcoordArray>()?;
     m.add_class::<PyTriangleArray>()?;
+    m.add_class::<PyRegularSubblockArray>()?;
+    m.add_class::<PyFreeformSubblockArray>()?;
     m.add_class::<PyNameArray>()?;
     m.add_class::<PyElement>()?;
     m.add_class::<PyGrid2Regular>()?;
     m.add_class::<PyGrid2Tensor>()?;
+    m.add_class::<PyGrid3Regular>()?;
+    m.add_class::<PyGrid3Tensor>()?;
     m.add_class::<PyOrient2>()?;
+    m.add_class::<PyOrient3>()?;
+    m.add_class::<PyBlockModel>()?;
     m.add_class::<PyGridSurface>()?;
     m.add_class::<PyPointSet>()?;
     m.add_class::<PyLineSet>()?;

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -1,4 +1,4 @@
-use block_model::PyBlockModel;
+use block_model::{PyBlockModel, PyFreeformSubblocks, PyRegularSubblocks, PySubblockMode};
 use grid::{PyGrid2Regular, PyGrid2Tensor, PyGrid3Regular, PyGrid3Tensor, PyOrient2, PyOrient3};
 /// Python bindings.
 use pyo3::prelude::*;
@@ -77,6 +77,9 @@ fn omf_python(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyTriangleArray>()?;
     m.add_class::<PyRegularSubblockArray>()?;
     m.add_class::<PyFreeformSubblockArray>()?;
+    m.add_class::<PyRegularSubblocks>()?;
+    m.add_class::<PyFreeformSubblocks>()?;
+    m.add_class::<PySubblockMode>()?;
     m.add_class::<PyNameArray>()?;
     m.add_class::<PyElement>()?;
     m.add_class::<PyGrid2Regular>()?;

--- a/omf-python/tests/test_block_model.py
+++ b/omf-python/tests/test_block_model.py
@@ -63,7 +63,16 @@ class TestBlockModel(TestCase):
         block_model : omf_python.BlockModel = project.elements()[6].geometry()
         self.assertIsInstance(block_model, omf_python.BlockModel)
 
-        subblocks_array = block_model.subblocks
+        regular_subblocks = block_model.subblocks
+        self.assertIsInstance(regular_subblocks, omf_python.RegularSubblocks)
+
+        expected_mode = omf_python.SubblockMode.Octree
+        self.assertEqual(expected_mode, regular_subblocks.mode)
+
+        expected_count = [4, 4, 4]
+        self.assertEqual(expected_count, regular_subblocks.count)
+
+        subblocks_array = regular_subblocks.subblocks
         self.assertIsInstance(subblocks_array, omf_python.RegularSubblockArray)
 
         expected_regular_subblock_values = [
@@ -90,7 +99,10 @@ class TestBlockModel(TestCase):
         block_model : omf_python.BlockModel = project.elements()[7].geometry()
         self.assertIsInstance(block_model, omf_python.BlockModel)
 
-        subblocks_array = block_model.subblocks
+        freeform_subblocks = block_model.subblocks
+        self.assertIsInstance(freeform_subblocks, omf_python.FreeformSubblocks)
+
+        subblocks_array = freeform_subblocks.subblocks
         self.assertIsInstance(subblocks_array, omf_python.FreeformSubblockArray)
 
         expected_freeform_subblock_values = [

--- a/omf-python/tests/test_block_model.py
+++ b/omf-python/tests/test_block_model.py
@@ -1,0 +1,115 @@
+import omf_python
+from os import path
+from unittest import TestCase
+
+
+class TestBlockModel(TestCase):
+    def setUp(self) -> None:
+        self.omf_dir = path.join(path.dirname(__file__), "data")
+        self.one_of_everything = path.join(self.omf_dir, "one_of_everything.omf")
+
+    def test_should_return_expected_regular_block_model(self) -> None:
+        reader = omf_python.Reader(self.one_of_everything)
+        project, _ = reader.project()
+        block_model : omf_python.BlockModel = project.elements()[4].geometry()
+        self.assertIsInstance(block_model, omf_python.BlockModel)
+
+        orientation = block_model.orient
+        self.assertEqual([-1, -1, -1], orientation.origin)
+        self.assertEqual([1, 0, 0], orientation.u)
+        self.assertEqual([0, 1, 0], orientation.v)
+        self.assertEqual([0, 0, 1], orientation.w)
+
+        grid = block_model.grid
+        self.assertIsInstance(grid, omf_python.Grid3Regular)
+        self.assertEqual([1,1,1], grid.size)
+        self.assertEqual([2,2,2], grid.count())
+        self.assertEqual(8, grid.flat_count())
+        self.assertEqual(27, grid.flat_corner_count())
+
+        subblocks = block_model.subblocks
+        self.assertIsNone(subblocks)
+
+    def test_should_have_expected_tensor_block_model(self) -> None:
+        reader = omf_python.Reader(self.one_of_everything)
+        project, _ = reader.project()
+        block_model : omf_python.BlockModel = project.elements()[5].geometry()
+        self.assertIsInstance(block_model, omf_python.BlockModel)
+
+        grid = block_model.grid
+        self.assertIsInstance(grid, omf_python.Grid3Tensor)
+        self.assertEqual([2,2,2], grid.count())
+        self.assertEqual(8, grid.flat_count())
+        self.assertEqual(27, grid.flat_corner_count())
+
+        u = grid.u
+        self.assertIsInstance(u, omf_python.ScalarArray)
+        self.assertEqual(2, u.item_count())
+        self.assertEqual([0.6666, 1.333], reader.array_scalars(u))
+
+        v = grid.v
+        self.assertIsInstance(v, omf_python.ScalarArray)
+        self.assertEqual(2, v.item_count())
+        self.assertEqual([0.6666, 1.333], reader.array_scalars(v))
+
+        w = grid.w
+        self.assertIsInstance(w, omf_python.ScalarArray)
+        self.assertEqual(2, w.item_count())
+        self.assertEqual([1.0, 1.0], reader.array_scalars(w))
+
+    def test_should_have_expected_regular_subblocks(self) -> None:
+        reader = omf_python.Reader(self.one_of_everything)
+        project, _ = reader.project()
+        block_model : omf_python.BlockModel = project.elements()[6].geometry()
+        self.assertIsInstance(block_model, omf_python.BlockModel)
+
+        subblocks_array = block_model.subblocks
+        self.assertIsInstance(subblocks_array, omf_python.RegularSubblockArray)
+
+        expected_regular_subblock_values = [
+            ([0, 0, 0], [0, 0, 0, 4, 4, 4]),
+            ([1, 0, 0], [0, 0, 0, 4, 4, 4]),
+            ([0, 1, 0], [0, 0, 0, 4, 4, 4]),
+            ([1, 1, 0], [0, 0, 0, 4, 4, 4]),
+            ([0, 0, 1], [0, 0, 0, 4, 4, 4]),
+            ([1, 0, 1], [0, 0, 0, 4, 4, 4]),
+            ([0, 1, 1], [0, 0, 0, 4, 4, 4]),
+            ([1, 1, 1], [0, 0, 0, 2, 2, 2]),
+            ([1, 1, 1], [0, 2, 0, 1, 3, 1]),
+            ([1, 1, 1], [2, 0, 0, 3, 1, 1]),
+            ([1, 1, 1], [0, 0, 2, 1, 1, 3]),
+        ]
+        self.assertListEqual(
+            expected_regular_subblock_values,
+            reader.array_regular_subblocks(subblocks_array)
+        )
+
+    def test_should_have_expected_freeform_subblocks(self) -> None:
+        reader = omf_python.Reader(self.one_of_everything)
+        project, _ = reader.project()
+        block_model : omf_python.BlockModel = project.elements()[7].geometry()
+        self.assertIsInstance(block_model, omf_python.BlockModel)
+
+        subblocks_array = block_model.subblocks
+        self.assertIsInstance(subblocks_array, omf_python.FreeformSubblockArray)
+
+        expected_freeform_subblock_values = [
+            ([0, 0, 0], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([1, 0, 0], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([0, 1, 0], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([1, 1, 0], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([0, 0, 1], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([1, 0, 1], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([0, 1, 1], [0.0, 0.0, 0.0, 1.0, 1.0, 1.0]),
+            ([1, 1, 1], [0.0, 0.0, 0.0, 1.0, 1.0, 0.3333]),
+            ([1, 1, 1], [0.0, 0.0, 0.3333, 0.75, 0.75, 0.6666]),
+            ([1, 1, 1], [0.0, 0.0, 0.6666, 0.5, 0.5, 1.0]),
+        ]
+
+        freeform_subblock_values = reader.array_freeform_subblocks(subblocks_array)
+
+        # Round floating point values to check they're almost equal
+        freeform_subblock_values = [
+            (a, [round(i, 4) for i in b]) for (a, b) in freeform_subblock_values
+        ]
+        self.assertListEqual(expected_freeform_subblock_values, freeform_subblock_values)

--- a/omf-python/tests/test_grid_surface.py
+++ b/omf-python/tests/test_grid_surface.py
@@ -15,7 +15,6 @@ class TestGridSurface(TestCase):
         self.assertIsInstance(grid_surface, omf_python.GridSurface)
 
         orientation = grid_surface.orient
-
         self.assertEqual([-1.5, -1.5, 0], orientation.origin)
         self.assertEqual([1, 0, 0], orientation.u)
         self.assertEqual([0, 1, 0], orientation.v)
@@ -27,7 +26,7 @@ class TestGridSurface(TestCase):
         )
 
         grid = grid_surface.grid
-        self.assertIsInstance(grid, omf_python.Tensor)
+        self.assertIsInstance(grid, omf_python.Grid2Tensor)
         self.assertEqual([2, 2], grid.count())
 
         u = grid.u


### PR DESCRIPTION
Rename Grid2 python classes to distinguish from Grid3 classes