### PR TITLE
Wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,15 @@ members = ["omf-c", "omf-python"]
 [workspace.dependencies]
 bytes = "1.8.0"
 cbindgen = { version = "0.27", default-features = false }
-chrono = { version = "0.4.38", default-features = false, features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 flate2 = "1.0.34"
 image = { version = "0.25.5", default-features = false, features = [
     "png",
     "jpeg",
 ] }
-parquet = { version = "53.2.0", default-features = false, features = ["flate2"] }
+parquet = { version = "53.2.0", default-features = false, features = [
+    "flate2",
+] }
 regex = "1.11.1"
 schemars = { version = "0.8.21", features = ["chrono"] }
 serde = { version = "1.0.215", features = ["derive"] }

--- a/omf-c/src/read_iterators.rs
+++ b/omf-c/src/read_iterators.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_char, ptr::null};
+use std::{ffi::c_char, fs::File, ptr::null};
 
 use crate::{
     error::{set_error, Error},
@@ -149,8 +149,8 @@ pub(crate) fn next_boundary<T: omf::data::NumberType>(
 
 // f32 scalars.
 
-pub struct Scalars32(omf::data::GenericScalars<f32>);
-pub(crate) fn scalars32_new(iter: omf::data::GenericScalars<f32>) -> *mut Scalars32 {
+pub struct Scalars32(omf::data::GenericScalars<f32, File>);
+pub(crate) fn scalars32_new(iter: omf::data::GenericScalars<f32, File>) -> *mut Scalars32 {
     alloc(Scalars32(iter))
 }
 
@@ -166,9 +166,9 @@ pub extern "C" fn omf_scalars32_next(iter: *mut Scalars32, value: *mut f32) -> b
 
 // f64 scalars, can cast from f32.
 
-pub struct Scalars64(omf::data::Scalars);
+pub struct Scalars64(omf::data::Scalars<File>);
 
-pub(crate) fn scalars64_new(iter: omf::data::Scalars) -> *mut Scalars64 {
+pub(crate) fn scalars64_new(iter: omf::data::Scalars<File>) -> *mut Scalars64 {
     alloc(Scalars64(iter))
 }
 
@@ -184,9 +184,9 @@ pub extern "C" fn omf_scalars64_next(iter: *mut Scalars64, value: *mut f64) -> b
 
 // f32 vertices.
 
-pub struct Vertices32(omf::data::GenericArrays<f32, 3>);
+pub struct Vertices32(omf::data::GenericArrays<f32, 3, File>);
 
-pub(crate) fn vertices32_new(iter: omf::data::GenericArrays<f32, 3>) -> *mut Vertices32 {
+pub(crate) fn vertices32_new(iter: omf::data::GenericArrays<f32, 3, File>) -> *mut Vertices32 {
     alloc(Vertices32(iter))
 }
 
@@ -201,9 +201,9 @@ pub extern "C" fn omf_vertices32_next(iter: *mut Vertices32, value: *mut f32) ->
 
 // f64 vertices, can cast from f32.
 
-pub struct Vertices64(omf::data::Vertices);
+pub struct Vertices64(omf::data::Vertices<File>);
 
-pub(crate) fn vertices64_new(iter: omf::data::Vertices) -> *mut Vertices64 {
+pub(crate) fn vertices64_new(iter: omf::data::Vertices<File>) -> *mut Vertices64 {
     alloc(Vertices64(iter))
 }
 
@@ -219,9 +219,9 @@ pub extern "C" fn omf_vertices64_next(iter: *mut Vertices64, value: *mut f64) ->
 
 // Segments.
 
-pub struct Segments(omf::data::GenericPrimitives<2>);
+pub struct Segments(omf::data::GenericPrimitives<2, File>);
 
-pub(crate) fn segments_new(iter: omf::data::GenericPrimitives<2>) -> *mut Segments {
+pub(crate) fn segments_new(iter: omf::data::GenericPrimitives<2, File>) -> *mut Segments {
     alloc(Segments(iter))
 }
 
@@ -237,8 +237,8 @@ pub extern "C" fn omf_segments_next(iter: *mut Segments, value: *mut u32) -> boo
 
 // Triangles.
 
-pub struct Triangles(omf::data::GenericPrimitives<3>);
-pub(crate) fn triangles_new(iter: omf::data::GenericPrimitives<3>) -> *mut Triangles {
+pub struct Triangles(omf::data::GenericPrimitives<3, File>);
+pub(crate) fn triangles_new(iter: omf::data::GenericPrimitives<3, File>) -> *mut Triangles {
     alloc(Triangles(iter))
 }
 
@@ -254,8 +254,8 @@ pub extern "C" fn omf_triangles_next(iter: *mut Triangles, value: *mut u32) -> b
 
 // Gradient.
 
-pub struct Gradient(omf::data::Gradient);
-pub(crate) fn gradient_new(iter: omf::data::Gradient) -> *mut Gradient {
+pub struct Gradient(omf::data::Gradient<File>);
+pub(crate) fn gradient_new(iter: omf::data::Gradient<File>) -> *mut Gradient {
     alloc(Gradient(iter))
 }
 
@@ -271,9 +271,9 @@ pub extern "C" fn omf_gradient_next(iter: *mut Gradient, value: *mut u8) -> bool
 
 // f32 texture coordinates.
 
-pub struct Texcoords32(omf::data::GenericArrays<f32, 2>);
+pub struct Texcoords32(omf::data::GenericArrays<f32, 2, File>);
 
-pub(crate) fn texcoords32_new(iter: omf::data::GenericArrays<f32, 2>) -> *mut Texcoords32 {
+pub(crate) fn texcoords32_new(iter: omf::data::GenericArrays<f32, 2, File>) -> *mut Texcoords32 {
     alloc(Texcoords32(iter))
 }
 
@@ -289,9 +289,9 @@ pub extern "C" fn omf_texcoords32_next(iter: *mut Texcoords32, value: *mut f32) 
 
 // f64 texcoords, can cast from f32.
 
-pub struct Texcoords64(omf::data::Texcoords);
+pub struct Texcoords64(omf::data::Texcoords<File>);
 
-pub(crate) fn texcoords64_new(iter: omf::data::Texcoords) -> *mut Texcoords64 {
+pub(crate) fn texcoords64_new(iter: omf::data::Texcoords<File>) -> *mut Texcoords64 {
     alloc(Texcoords64(iter))
 }
 
@@ -307,9 +307,11 @@ pub extern "C" fn omf_texcoords64_next(iter: *mut Texcoords64, value: *mut f64) 
 
 // f64 discrete colormap boundaries.
 
-pub struct BoundariesFloat64(omf::data::BoundariesF64);
+pub struct BoundariesFloat64(omf::data::BoundariesF64<File>);
 
-pub(crate) fn boundaries_float64_new(iter: omf::data::BoundariesF64) -> *mut BoundariesFloat64 {
+pub(crate) fn boundaries_float64_new(
+    iter: omf::data::BoundariesF64<File>,
+) -> *mut BoundariesFloat64 {
     alloc(BoundariesFloat64(iter))
 }
 
@@ -329,10 +331,10 @@ pub extern "C" fn omf_boundaries_float64_next(
 
 // f32 discrete colormap boundaries.
 
-pub struct BoundariesFloat32(omf::data::GenericBoundaries<f32>);
+pub struct BoundariesFloat32(omf::data::GenericBoundaries<f32, File>);
 
 pub(crate) fn boundaries_float32_new(
-    iter: omf::data::GenericBoundaries<f32>,
+    iter: omf::data::GenericBoundaries<f32, File>,
 ) -> *mut BoundariesFloat32 {
     alloc(BoundariesFloat32(iter))
 }
@@ -353,9 +355,9 @@ pub extern "C" fn omf_boundaries_float32_next(
 
 // i64 discrete colormap boundaries.
 
-pub struct BoundariesInt64(omf::data::BoundariesI64);
+pub struct BoundariesInt64(omf::data::BoundariesI64<File>);
 
-pub(crate) fn boundaries_int64_new(iter: omf::data::BoundariesI64) -> *mut BoundariesInt64 {
+pub(crate) fn boundaries_int64_new(iter: omf::data::BoundariesI64<File>) -> *mut BoundariesInt64 {
     alloc(BoundariesInt64(iter))
 }
 
@@ -375,9 +377,11 @@ pub extern "C" fn omf_boundaries_int64_next(
 
 // f32 numbers.
 
-pub struct NumbersFloat32(omf::data::GenericNumbers<f32>);
+pub struct NumbersFloat32(omf::data::GenericNumbers<f32, File>);
 
-pub(crate) fn numbers_float32_new(iter: omf::data::GenericNumbers<f32>) -> *mut NumbersFloat32 {
+pub(crate) fn numbers_float32_new(
+    iter: omf::data::GenericNumbers<f32, File>,
+) -> *mut NumbersFloat32 {
     alloc(NumbersFloat32(iter))
 }
 
@@ -397,9 +401,9 @@ pub extern "C" fn omf_numbers_float32_next(
 
 // f64 numbers, casting from date and date-time as well.
 
-pub struct NumbersFloat64(omf::data::NumbersF64);
+pub struct NumbersFloat64(omf::data::NumbersF64<File>);
 
-pub(crate) fn numbers_float64_new(iter: omf::data::NumbersF64) -> *mut NumbersFloat64 {
+pub(crate) fn numbers_float64_new(iter: omf::data::NumbersF64<File>) -> *mut NumbersFloat64 {
     alloc(NumbersFloat64(iter))
 }
 
@@ -419,9 +423,9 @@ pub extern "C" fn omf_numbers_float64_next(
 
 // i64 numbers, casting from date and date-time as well.
 
-pub struct NumbersInt64(omf::data::NumbersI64);
+pub struct NumbersInt64(omf::data::NumbersI64<File>);
 
-pub(crate) fn numbers_int64_new(iter: omf::data::NumbersI64) -> *mut NumbersInt64 {
+pub(crate) fn numbers_int64_new(iter: omf::data::NumbersI64<File>) -> *mut NumbersInt64 {
     alloc(NumbersInt64(iter))
 }
 
@@ -441,9 +445,9 @@ pub extern "C" fn omf_numbers_int64_next(
 
 // Nullable indices.
 
-pub struct Indices(omf::data::Indices);
+pub struct Indices(omf::data::Indices<File>);
 
-pub(crate) fn indices_new(iter: omf::data::Indices) -> *mut Indices {
+pub(crate) fn indices_new(iter: omf::data::Indices<File>) -> *mut Indices {
     alloc(Indices(iter))
 }
 
@@ -463,9 +467,9 @@ pub extern "C" fn omf_indices_next(
 
 // Nullable booleans.
 
-pub struct Booleans(omf::data::Booleans);
+pub struct Booleans(omf::data::Booleans<File>);
 
-pub(crate) fn booleans_new(iter: omf::data::Booleans) -> *mut Booleans {
+pub(crate) fn booleans_new(iter: omf::data::Booleans<File>) -> *mut Booleans {
     alloc(Booleans(iter))
 }
 
@@ -485,8 +489,8 @@ pub extern "C" fn omf_booleans_next(
 
 // Nullable colors.
 
-pub struct Colors(omf::data::Colors);
-pub(crate) fn colors_new(iter: omf::data::Colors) -> *mut Colors {
+pub struct Colors(omf::data::Colors<File>);
+pub(crate) fn colors_new(iter: omf::data::Colors<File>) -> *mut Colors {
     alloc(Colors(iter))
 }
 
@@ -507,11 +511,11 @@ pub extern "C" fn omf_omf_colors_next(
 // Non-nullable name strings.
 
 pub struct Names {
-    iter: omf::data::Names,
+    iter: omf::data::Names<File>,
     bytes: BytesCache,
 }
 
-pub(crate) fn names_new(iter: omf::data::Names) -> *mut Names {
+pub(crate) fn names_new(iter: omf::data::Names<File>) -> *mut Names {
     Box::into_raw(Box::new(Names {
         iter,
         bytes: Default::default(),
@@ -549,11 +553,11 @@ pub extern "C" fn omf_names_next(
 // Nullable text strings.
 
 pub struct Text {
-    iter: omf::data::Text,
+    iter: omf::data::Text<File>,
     bytes: BytesCache,
 }
 
-pub(crate) fn text_new(iter: omf::data::Text) -> *mut Text {
+pub(crate) fn text_new(iter: omf::data::Text<File>) -> *mut Text {
     Box::into_raw(Box::new(Text {
         iter,
         bytes: Default::default(),
@@ -595,9 +599,11 @@ pub extern "C" fn omf_text_next(
 
 // Regular sub-blocks
 
-pub struct RegularSubblocks(omf::data::RegularSubblocks);
+pub struct RegularSubblocks(omf::data::RegularSubblocks<File>);
 
-pub(crate) fn regular_subblocks_new(iter: omf::data::RegularSubblocks) -> *mut RegularSubblocks {
+pub(crate) fn regular_subblocks_new(
+    iter: omf::data::RegularSubblocks<File>,
+) -> *mut RegularSubblocks {
     alloc(RegularSubblocks(iter))
 }
 
@@ -632,10 +638,10 @@ pub extern "C" fn omf_regular_subblocks_next(
 
 // Free-form sub-blocks with f64 corners, casts from f64
 
-pub struct FreeformSubblocks32(omf::data::GenericFreeformSubblocks<f32>);
+pub struct FreeformSubblocks32(omf::data::GenericFreeformSubblocks<f32, File>);
 
 pub(crate) fn freeform_subblocks32_new(
-    iter: omf::data::GenericFreeformSubblocks<f32>,
+    iter: omf::data::GenericFreeformSubblocks<f32, File>,
 ) -> *mut FreeformSubblocks32 {
     alloc(FreeformSubblocks32(iter))
 }
@@ -671,10 +677,10 @@ pub extern "C" fn omf_freeform_subblocks32_next(
 
 // Free-form sub-blocks with f32 corners
 
-pub struct FreeformSubblocks64(omf::data::FreeformSubblocks);
+pub struct FreeformSubblocks64(omf::data::FreeformSubblocks<File>);
 
 pub(crate) fn freeform_subblocks64_new(
-    iter: omf::data::FreeformSubblocks,
+    iter: omf::data::FreeformSubblocks<File>,
 ) -> *mut FreeformSubblocks64 {
     alloc(FreeformSubblocks64(iter))
 }
@@ -710,9 +716,9 @@ pub extern "C" fn omf_freeform_subblocks64_next(
 
 // 3D vectors with type f64, casts from anything
 
-pub struct Vectors64x3(omf::data::Vectors);
+pub struct Vectors64x3(omf::data::Vectors<File>);
 
-pub(crate) fn vectors64x3_new(iter: omf::data::Vectors) -> *mut Vectors64x3 {
+pub(crate) fn vectors64x3_new(iter: omf::data::Vectors<File>) -> *mut Vectors64x3 {
     alloc(Vectors64x3(iter))
 }
 
@@ -735,11 +741,11 @@ pub extern "C" fn omf_vectors64x3_next(
 pub struct Vectors32x3(Vec32Iter);
 
 enum Vec32Iter {
-    X2(omf::data::GenericOptionalArrays<f32, 2>),
-    X3(omf::data::GenericOptionalArrays<f32, 3>),
+    X2(omf::data::GenericOptionalArrays<f32, 2, File>),
+    X3(omf::data::GenericOptionalArrays<f32, 3, File>),
 }
 
-pub(crate) fn vectors32x3_new(iter: omf::data::Vectors) -> *mut Vectors32x3 {
+pub(crate) fn vectors32x3_new(iter: omf::data::Vectors<File>) -> *mut Vectors32x3 {
     let vec32_iter = match iter {
         omf::data::Vectors::F32x2(i) => Vec32Iter::X2(i),
         omf::data::Vectors::F32x3(i) => Vec32Iter::X3(i),
@@ -778,11 +784,11 @@ fn vec_2d_to_3d<T: omf::data::FloatType>([x, y]: [T; 2]) -> [T; 3] {
 pub struct Vectors64x2(Vec2DIter);
 
 enum Vec2DIter {
-    F32(omf::data::GenericOptionalArrays<f32, 2>),
-    F64(omf::data::GenericOptionalArrays<f64, 2>),
+    F32(omf::data::GenericOptionalArrays<f32, 2, File>),
+    F64(omf::data::GenericOptionalArrays<f64, 2, File>),
 }
 
-pub(crate) fn vectors64x2_new(iter: omf::data::Vectors) -> *mut Vectors64x2 {
+pub(crate) fn vectors64x2_new(iter: omf::data::Vectors<File>) -> *mut Vectors64x2 {
     let vec32_iter = match iter {
         omf::data::Vectors::F32x2(i) => Vec2DIter::F32(i),
         omf::data::Vectors::F64x2(i) => Vec2DIter::F64(i),
@@ -816,9 +822,11 @@ pub extern "C" fn omf_vectors64x2_next(
 
 // 2D vectors with type f32, no casting
 
-pub struct Vectors32x2(omf::data::GenericOptionalArrays<f32, 2>);
+pub struct Vectors32x2(omf::data::GenericOptionalArrays<f32, 2, File>);
 
-pub(crate) fn vectors32x2_new(iter: omf::data::GenericOptionalArrays<f32, 2>) -> *mut Vectors32x2 {
+pub(crate) fn vectors32x2_new(
+    iter: omf::data::GenericOptionalArrays<f32, 2, File>,
+) -> *mut Vectors32x2 {
     alloc(Vectors32x2(iter))
 }
 

--- a/omf-c/src/reader.rs
+++ b/omf-c/src/reader.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_char, io::Read, path::PathBuf, ptr::null_mut, sync::Mutex};
+use std::{ffi::c_char, fs::File, io::Read, path::PathBuf, ptr::null_mut, sync::Mutex};
 
 use crate::{
     arrays::{array, array_action, Array, ArrayType},
@@ -14,7 +14,7 @@ use crate::{
 };
 
 struct ReaderWrapper {
-    pub inner: omf::file::Reader,
+    pub inner: omf::file::Reader<File>,
     pub storage: FfiStorage,
     pub project_loaded: bool,
 }

--- a/omf-c/src/writer.rs
+++ b/omf-c/src/writer.rs
@@ -29,7 +29,7 @@ use crate::{
 
 pub(crate) struct WriterWrapper {
     pub path: PathBuf,
-    pub inner: omf::file::Writer,
+    pub inner: omf::file::Writer<File>,
     pub project: Option<omf::Project>,
     pub storage: FfiStorage,
 }

--- a/omf-python/src/file/reader.rs
+++ b/omf-python/src/file/reader.rs
@@ -212,7 +212,7 @@ fn zipped_pyarray2_from_iter<
 ///     where data is maliciously crafted to expand to an excessive size when decompressed,
 ///     leading to a potential denial of service attack.
 ///     Use the limits provided and check arrays sizes before allocating memory.
-pub struct PyReader(Reader);
+pub struct PyReader(Reader<File>);
 
 #[gen_stub_pymethods]
 #[pymethods]

--- a/src/date_time.rs
+++ b/src/date_time.rs
@@ -1,6 +1,6 @@
 //! Utility functions for date and date-time conversion.
 
-use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
 
 /// Convert a date to the number of days since the epoch.
 pub fn date_to_f64(date: NaiveDate) -> f64 {
@@ -73,11 +73,5 @@ pub fn i64_nano_to_date_time(value: i64) -> DateTime<Utc> {
 
 /// Returns the current date and time in UTC.
 pub fn utc_now() -> DateTime<Utc> {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("valid system time");
-    let naive = DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos())
-        .expect("valid timestamp")
-        .naive_utc();
-    Utc.from_utc_datetime(&naive)
+    chrono::Utc::now()
 }

--- a/src/file/image.rs
+++ b/src/file/image.rs
@@ -1,8 +1,8 @@
-use std::io::{BufReader, Cursor};
+use std::io::{BufReader, Cursor, Seek, Write};
 
 use crate::{array_type, error::Error, Array};
 
-use super::{Limits, Reader, Writer};
+use super::{Limits, ReadAt, Reader, Writer};
 
 impl From<Limits> for image::Limits {
     fn from(value: Limits) -> Self {
@@ -14,7 +14,7 @@ impl From<Limits> for image::Limits {
     }
 }
 
-impl Reader {
+impl<R: ReadAt> Reader<R> {
     /// Read and decode an image.
     pub fn image(&self, image: &Array<array_type::Image>) -> Result<image::DynamicImage, Error> {
         let f = BufReader::new(self.array_bytes_reader(image)?);
@@ -24,7 +24,7 @@ impl Reader {
     }
 }
 
-impl Writer {
+impl<W: Write + Seek> Writer<W> {
     /// Write an image in PNG encoding.
     ///
     /// This supports grayscale, grayscale + alpha, RGB, and RGBA, in 8 or 16 bits per channel.

--- a/src/file/mod.rs
+++ b/src/file/mod.rs
@@ -4,11 +4,15 @@
 mod image;
 #[cfg(feature = "parquet")]
 pub(crate) mod parquet;
+mod read_at;
 mod reader;
 mod sub_file;
+mod write_to;
 mod writer;
 mod zip_container;
 
+pub use read_at::ReadAt;
 pub use reader::{Limits, Reader};
 pub use sub_file::SubFile;
+pub use write_to::WriteTo;
 pub use writer::{Compression, Writer};

--- a/src/file/parquet/schemas.rs
+++ b/src/file/parquet/schemas.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 
 use crate::{
-    file::SubFile,
+    file::{ReadAt, SubFile},
     pqarray::{schema_match, PqArrayMatcher, PqArrayReader},
 };
 
@@ -22,8 +22,8 @@ macro_rules! declare_schema {
                 })
             }
 
-            pub fn check(
-                reader: &PqArrayReader<SubFile>,
+            pub fn check<R: ReadAt>(
+                reader: &PqArrayReader<SubFile<R>>,
             ) -> Result<$name, crate::error::Error> {
                 reader.matches(Self::matcher())
             }

--- a/src/file/parquet/writer.rs
+++ b/src/file/parquet/writer.rs
@@ -1,3 +1,5 @@
+use std::io::{Seek, Write};
+
 use crate::{
     array_type,
     data::{write_checks::*, *},
@@ -18,7 +20,7 @@ impl From<Compression> for PqWriteOptions {
     }
 }
 
-impl Writer {
+impl<W: Write + Seek + Send> Writer<W> {
     fn array_writer<'a>(&self) -> PqArrayWriter<'a> {
         PqArrayWriter::new(self.compression().into())
     }

--- a/src/file/read_at.rs
+++ b/src/file/read_at.rs
@@ -28,7 +28,7 @@ impl ReadAt for std::fs::File {
 impl ReadAt for std::fs::File {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
         use std::os::unix::fs::FileExt;
-        file.read_at(buf, offset)
+        self.read_at(buf, offset)
     }
 
     fn size(&self) -> std::io::Result<u64> {

--- a/src/file/read_at.rs
+++ b/src/file/read_at.rs
@@ -28,7 +28,7 @@ impl ReadAt for std::fs::File {
 impl ReadAt for std::fs::File {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
         use std::os::unix::fs::FileExt;
-        self.read_at(buf, offset)
+        FileExt::read_at(self, buf, offset)
     }
 
     fn size(&self) -> std::io::Result<u64> {

--- a/src/file/read_at.rs
+++ b/src/file/read_at.rs
@@ -1,0 +1,72 @@
+/// Read from a file-like object at an offset.
+pub trait ReadAt: Send + Sync + 'static {
+    /// Seeks to `offset` and performs reads into `buf`.
+    ///
+    /// Returns the number of bytes read.
+    ///
+    /// Note that similar to File::read, it is not an error to return with a short read.
+    /// May or may not move any underlying file pointer, even if the read fails or is short.
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize>;
+
+    /// Returns the length of the data.
+    fn size(&self) -> std::io::Result<u64>;
+}
+
+#[cfg(windows)]
+impl ReadAt for std::fs::File {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        use std::os::windows::fs::FileExt;
+        self.seek_read(buf, offset)
+    }
+
+    fn size(&self) -> std::io::Result<u64> {
+        self.metadata().map(|m| m.len())
+    }
+}
+
+#[cfg(unix)]
+impl ReadAt for std::fs::File {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        use std::os::unix::fs::FileExt;
+        file.read_at(buf, offset)
+    }
+
+    fn len(&self) -> std::io::Result<u64> {
+        self.metadata().map(|m| m.len())
+    }
+}
+
+impl ReadAt for Vec<u8> {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        let start = usize::try_from(offset).expect("offset must fit in usize");
+        let end = start.saturating_add(buf.len()).min(self.len());
+        let slice = &self[start..end];
+        buf[..slice.len()].copy_from_slice(slice);
+        Ok(slice.len())
+    }
+
+    fn size(&self) -> std::io::Result<u64> {
+        Ok(self.len().try_into().expect("length must fit in u64"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_at_vec_middle() {
+        let data = vec![1, 2, 3, 4, 5];
+        let mut buf = [0; 3];
+        assert_eq!(data.read_at(&mut buf, 1).unwrap(), 3);
+        assert_eq!(&buf, &[2, 3, 4]);
+    }
+
+    #[test]
+    fn read_at_vec_end() {
+        let data = vec![1, 2, 3, 4, 5];
+        let mut buf = [0; 3];
+        assert_eq!(data.read_at(&mut buf, 3).unwrap(), 2);
+        assert_eq!(&buf, &[4, 5, 0]);
+    }
+}

--- a/src/file/read_at.rs
+++ b/src/file/read_at.rs
@@ -31,7 +31,7 @@ impl ReadAt for std::fs::File {
         file.read_at(buf, offset)
     }
 
-    fn len(&self) -> std::io::Result<u64> {
+    fn size(&self) -> std::io::Result<u64> {
         self.metadata().map(|m| m.len())
     }
 }

--- a/src/file/write_to.rs
+++ b/src/file/write_to.rs
@@ -1,0 +1,5 @@
+use std::io::{Seek, Write};
+
+pub trait WriteTo: Write + Seek {}
+
+impl<T: Write + Seek> WriteTo for T {}

--- a/src/file/writer.rs
+++ b/src/file/writer.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     fs::{File, OpenOptions},
-    io::{Read, Write},
+    io::{Read, Seek, Write},
     path::Path,
 };
 
@@ -77,20 +77,12 @@ impl From<Compression> for flate2::Compression {
 ///     1. Fill in the required struct with the array pointers and other details then add it to the project.
 ///     1. Repeat for the attributes, adding them to the newly created element.
 /// 1. Call `writer.finish(project)` to validate everything inside the the project and write it.
-pub struct Writer {
-    pub(crate) builder: Builder,
+pub struct Writer<W: Write + Seek> {
+    pub(crate) builder: Builder<W>,
     compression: Compression,
 }
 
-impl Writer {
-    /// Creates a writer that writes into a file-like object.
-    pub fn new(file: File) -> Result<Self, Error> {
-        Ok(Self {
-            builder: Builder::new(file)?,
-            compression: Default::default(),
-        })
-    }
-
+impl Writer<File> {
     /// Creates a writer by opening a file.
     ///
     /// The file will be created if it doesn't exist, and truncated and replaced if it does.
@@ -102,6 +94,16 @@ impl Writer {
                 .create(true)
                 .open(path)?,
         )
+    }
+}
+
+impl<W: Write + Seek> Writer<W> {
+    /// Creates a writer that writes into a file-like object.
+    pub fn new(write: W) -> Result<Self, Error> {
+        Ok(Self {
+            builder: Builder::new(write)?,
+            compression: Default::default(),
+        })
     }
 
     /// Return the current compression.
@@ -173,7 +175,7 @@ impl Writer {
     ///
     /// Returns validation warnings on success or an [`Error`] on failure, which can be a
     /// validation failure or a file IO error.
-    pub fn finish(mut self, mut project: Project) -> Result<(File, Problems), Error> {
+    pub fn finish(mut self, mut project: Project) -> Result<(W, Problems), Error> {
         let mut val = Validator::new().with_filenames(self.builder.filenames());
         project.validate_inner(&mut val);
         let warnings = val.finish().into_result()?;
@@ -181,12 +183,12 @@ impl Writer {
         serde_json::to_writer(gz, &project).map_err(Error::SerializationFailed)?;
         // In the future we could base the format version on the data, writing backward
         // compatible files if new features weren't used.
-        let file = self.builder.finish(
+        let write = self.builder.finish(
             FORMAT_VERSION_MAJOR,
             FORMAT_VERSION_MINOR,
             FORMAT_VERSION_PRERELEASE,
         )?;
-        Ok((file, warnings))
+        Ok((write, warnings))
     }
 }
 

--- a/src/file/zip_container.rs
+++ b/src/file/zip_container.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, fs::File, sync::Arc};
+use std::{
+    collections::HashMap,
+    io::{Seek, Write},
+};
 
 use zip::{
     read::{ZipArchive, ZipFile},
@@ -7,7 +10,7 @@ use zip::{
 
 use crate::{error::Error, FORMAT_NAME};
 
-use super::SubFile;
+use super::{ReadAt, SubFile};
 
 pub(crate) const INDEX_NAME: &str = "index.json.gz";
 pub(crate) const PARQUET_EXT: &str = ".parquet";
@@ -21,16 +24,16 @@ pub(crate) enum FileType {
     Jpeg,
 }
 
-pub(crate) struct Builder {
-    zip_writer: ZipWriter<File>,
+pub(crate) struct Builder<W: Write + Seek> {
+    zip_writer: ZipWriter<W>,
     next_id: u64,
     filenames: Vec<String>,
 }
 
-impl Builder {
-    pub fn new(file: File) -> Result<Self, Error> {
+impl<W: Write + Seek> Builder<W> {
+    pub fn new(write: W) -> Result<Self, Error> {
         Ok(Self {
-            zip_writer: ZipWriter::new(file),
+            zip_writer: ZipWriter::new(write),
             next_id: 1,
             filenames: Vec::new(),
         })
@@ -42,7 +45,7 @@ impl Builder {
         i
     }
 
-    pub fn open(&mut self, file_type: FileType) -> Result<SubFileWrite<'_>, Error> {
+    pub fn open(&mut self, file_type: FileType) -> Result<SubFileWrite<'_, W>, Error> {
         let name = match file_type {
             FileType::Index => INDEX_NAME.to_owned(),
             FileType::Parquet => format!("{}{PARQUET_EXT}", self.id()),
@@ -66,12 +69,7 @@ impl Builder {
         self.filenames.iter().map(|s| &**s)
     }
 
-    pub fn finish(
-        mut self,
-        major: u32,
-        minor: u32,
-        pre_release: Option<&str>,
-    ) -> Result<File, Error> {
+    pub fn finish(mut self, major: u32, minor: u32, pre_release: Option<&str>) -> Result<W, Error> {
         use std::fmt::Write;
         let mut comment = format!("{FORMAT_NAME} {major}.{minor}");
         if let Some(pre) = pre_release {
@@ -82,18 +80,18 @@ impl Builder {
     }
 }
 
-pub(crate) struct SubFileWrite<'a> {
+pub(crate) struct SubFileWrite<'a, W: Write + Seek> {
     name: String,
-    inner: &'a mut ZipWriter<File>,
+    inner: &'a mut ZipWriter<W>,
 }
 
-impl SubFileWrite<'_> {
+impl<W: Write + Seek> SubFileWrite<'_, W> {
     pub fn name(&self) -> &str {
         &self.name
     }
 }
 
-impl std::io::Write for SubFileWrite<'_> {
+impl<W: Write + Seek> std::io::Write for SubFileWrite<'_, W> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.inner.write(buf)
     }
@@ -118,15 +116,15 @@ impl<'a> From<ZipFile<'a>> for FileSpan {
     }
 }
 
-pub(crate) struct Archive {
-    file: Arc<File>,
+pub(crate) struct Archive<R> {
+    file: SubFile<R>,
     members: HashMap<String, FileSpan>,
     version: [u32; 2],
     pre_release: Option<String>,
 }
 
-impl Archive {
-    pub fn new(file: File) -> Result<Self, Error> {
+impl<R: ReadAt> Archive<R> {
+    pub fn new(file: SubFile<R>) -> Result<Self, Error> {
         let mut zip_archive = ZipArchive::new(file)?;
         let mut members = HashMap::new();
         let mut index_found = false;
@@ -169,12 +167,12 @@ impl Archive {
             .copied()
     }
 
-    pub fn open(&self, name: &str) -> Result<SubFile, Error> {
+    pub fn open(&self, name: &str) -> Result<SubFile<R>, Error> {
         let span = self
             .members
             .get(name)
             .ok_or_else(|| Error::ZipMemberMissing(name.to_owned()))?;
-        Ok(SubFile::new(self.file.clone(), span.offset, span.size)?)
+        Ok(self.file.sub_file(span.offset, span.size)?)
     }
 }
 

--- a/src/file/zip_container.rs
+++ b/src/file/zip_container.rs
@@ -145,7 +145,7 @@ impl<R: ReadAt> Archive<R> {
             ));
         };
         Ok(Self {
-            file: zip_archive.into_inner().into(),
+            file: zip_archive.into_inner(),
             members,
             version,
             pre_release,

--- a/src/omf1/attributes.rs
+++ b/src/omf1/attributes.rs
@@ -1,4 +1,9 @@
-use crate::{error::Error, file::Writer};
+use std::io::{Seek, Write};
+
+use crate::{
+    error::Error,
+    file::{ReadAt, Writer},
+};
 
 use super::{
     array::{color_array, index_array, numbers_array, vectors2_array, vectors3_array},
@@ -9,7 +14,11 @@ use super::{
 };
 
 impl ScalarData {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         attribute(
             &self.content,
             self.location,
@@ -26,7 +35,11 @@ impl ScalarData {
 }
 
 impl DateTimeData {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         attribute(
             &self.content,
             self.location,
@@ -43,7 +56,11 @@ impl DateTimeData {
 }
 
 impl Vector2Data {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         attribute(
             &self.content,
             self.location,
@@ -55,7 +72,11 @@ impl Vector2Data {
 }
 
 impl Vector3Data {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         attribute(
             &self.content,
             self.location,
@@ -67,7 +88,11 @@ impl Vector3Data {
 }
 
 impl ColorData {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         match r.model(&self.array)? {
             ColorArrayModel::Int3Array(array) => attribute(
                 &self.content,
@@ -89,7 +114,11 @@ impl ColorData {
 }
 
 impl StringData {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         let strings = &r.model(&self.array)?.array;
         attribute(
             &self.content,
@@ -108,7 +137,11 @@ impl StringData {
 }
 
 impl MappedData {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         let (max_index, values) = index_array(r, w, &self.array)?;
         let mut handler = CategoryHandler::new(max_index);
         for key in &self.legends {
@@ -125,7 +158,11 @@ impl MappedData {
 }
 
 impl ImageTexture {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::Attribute, Error> {
+    pub fn convert<W: Write + Seek, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::Attribute, Error> {
         let (u, width) = projection_axis(self.axis_u);
         let (v, height) = projection_axis(self.axis_v);
         Ok(crate::Attribute {
@@ -149,7 +186,11 @@ impl ImageTexture {
 }
 
 impl ScalarColormap {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::NumberColormap, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::NumberColormap, Error> {
         let [min, max] = self.limits;
         Ok(crate::NumberColormap::Continuous {
             range: (min, max).into(),
@@ -159,7 +200,11 @@ impl ScalarColormap {
 }
 
 impl DateTimeColormap {
-    pub fn convert(&self, r: &Omf1Reader, w: &mut Writer) -> Result<crate::NumberColormap, Error> {
+    pub fn convert<W: Write + Seek + Send, R: ReadAt>(
+        &self,
+        r: &Omf1Reader<R>,
+        w: &mut Writer<W>,
+    ) -> Result<crate::NumberColormap, Error> {
         let [min, max] = self.limits;
         Ok(crate::NumberColormap::Continuous {
             range: (min, max).into(),
@@ -168,9 +213,9 @@ impl DateTimeColormap {
     }
 }
 
-fn gradient(
-    r: &Omf1Reader,
-    w: &mut Writer,
+fn gradient<W: Write + Seek + Send, R: ReadAt>(
+    r: &Omf1Reader<R>,
+    w: &mut Writer<W>,
     colors: &Key<ColorArray>,
 ) -> Result<crate::Array<crate::array_type::Gradient>, Error> {
     w.array_gradient(

--- a/src/omf1/category_handler.rs
+++ b/src/omf1/category_handler.rs
@@ -1,9 +1,15 @@
 use core::panic;
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    io::{Seek, Write},
+};
 
 use chrono::{DateTime, Utc};
 
-use crate::{error::Error, file::Writer};
+use crate::{
+    error::Error,
+    file::{ReadAt, Writer},
+};
 
 use super::{
     array::{load_scalars, ScalarValues},
@@ -61,7 +67,11 @@ impl Data {
 }
 
 impl Legend {
-    fn write(self, w: &mut Writer, len: usize) -> Result<crate::Attribute, Error> {
+    fn write<W: Write + Seek + Send>(
+        self,
+        w: &mut Writer<W>,
+        len: usize,
+    ) -> Result<crate::Attribute, Error> {
         let data = match self.data {
             Data::Color(colors) => crate::AttributeData::Color {
                 values: w.array_colors(iter_to_len(
@@ -128,9 +138,9 @@ impl CategoryHandler {
         }
     }
 
-    pub fn add(
+    pub fn add<R: ReadAt>(
         &mut self,
-        r: &Omf1Reader,
+        r: &Omf1Reader<R>,
         name: &str,
         description: &str,
         key: &Key<LegendArrays>,
@@ -198,9 +208,9 @@ impl CategoryHandler {
         }
     }
 
-    pub fn write(
+    pub fn write<W: Write + Seek + Send>(
         mut self,
-        w: &mut Writer,
+        w: &mut Writer<W>,
         values: crate::Array<crate::array_type::Index>,
     ) -> Result<crate::AttributeData, Error> {
         self.process();

--- a/src/omf1/mod.rs
+++ b/src/omf1/mod.rs
@@ -45,6 +45,8 @@ mod model;
 mod objects;
 mod reader;
 
-pub use converter::{detect, detect_open, Converter};
+#[cfg(not(target_family = "wasm"))]
+pub use converter::detect_open;
+pub use converter::{detect, Converter};
 pub use error::Omf1Error;
 pub use model::ModelType;

--- a/src/omf1/reader.rs
+++ b/src/omf1/reader.rs
@@ -41,7 +41,7 @@ impl<R: ReadAt> Omf1Reader<R> {
         let models: HashMap<String, Model> =
             serde_json::from_reader(&mut file).map_err(Omf1Error::DeserializationFailed)?;
         Ok(Self {
-            file: file.into(),
+            file,
             project,
             models,
             version,

--- a/src/omf1/reader.rs
+++ b/src/omf1/reader.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    fs::File,
     io::{BufReader, Read, Seek, SeekFrom},
     sync::Arc,
 };
@@ -9,7 +8,7 @@ use flate2::bufread::ZlibDecoder;
 
 use crate::{
     error::{Error, Limit},
-    file::SubFile,
+    file::{ReadAt, SubFile},
 };
 
 use super::{
@@ -20,16 +19,17 @@ use super::{
 
 /// The OMF1 file loader.
 #[derive(Debug)]
-pub struct Omf1Reader {
-    file: Arc<File>,
+pub struct Omf1Reader<R> {
+    file: SubFile<R>,
     project: Key<Project>,
     models: HashMap<String, Model>,
     version: String,
 }
 
-impl Omf1Reader {
-    pub fn new(mut file: File, limit: Option<u64>) -> Result<Self, Error> {
-        file.rewind()?;
+impl<R: ReadAt> Omf1Reader<R> {
+    pub fn new(data: R, limit: Option<u64>) -> Result<Self, Error> {
+        let size = data.size()?;
+        let mut file = SubFile::new(Arc::new(data), 0, size)?;
         let (project, json_start, version) = read_header(&mut file)?;
         let stream_len = file.seek(SeekFrom::End(0))?;
         if let Some(lim) = limit {
@@ -70,22 +70,18 @@ impl Omf1Reader {
     }
 
     pub fn image(&self, array: &Image) -> Result<impl Read, Error> {
-        Ok(ZlibDecoder::new(BufReader::new(SubFile::new(
-            self.file.clone(),
-            array.start,
-            array.length,
-        )?)))
+        Ok(ZlibDecoder::new(BufReader::new(
+            self.file.sub_file(array.start, array.length)?,
+        )))
     }
 
     pub fn array_decompressed_bytes(
         &self,
         array: &Array,
     ) -> Result<impl Iterator<Item = Result<u8, std::io::Error>>, Error> {
-        Ok(ZlibDecoder::new(BufReader::new(SubFile::new(
-            self.file.clone(),
-            array.start,
-            array.length,
-        )?))
+        Ok(ZlibDecoder::new(BufReader::new(
+            self.file.sub_file(array.start, array.length)?,
+        ))
         .bytes())
     }
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -46,7 +46,7 @@ pub struct Project {
     /// Optional name and version of the application that created the file, default empty.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub application: String,
-    /// Optional file or data creation date, default empty.
+    /// File or data creation date. Defaults to the current date and time on creation.
     pub date: DateTime<Utc>,
     /// Arbitrary metadata.
     ///


### PR DESCRIPTION
This changes the Rust Reader and Writer objects to be generic over the data source, rather than only using `std::fs::File`. The C and Python versions are unchanged. This allowed me to use the crate from Web-Assembly in my [Gneiss demo](https://redesigned-adventure-ev5gvry.pages.github.io/), and could be useful to others wanted to do the same. It does not actually provide a JavaScript API to call, so anyone wanting to use it would need to write their own task-specific wrappers.

With more changes this would also allow the Python API to read from a buffer or Python file-like object rather than only files.