### PR TITLE
Build Python wheels for MacOS

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,14 +116,12 @@ jobs:
       matrix:
         platform:
           - runner: macos-latest
-            # Assume M1+ chips going forwards for Mac, do not build for Intel
-            target: arm64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-          architecture: ${{ matrix.platform.target }}
+          architecture: arm64
       - uses: actions/download-artifact@v4
         with:
           name: omf-python-stub
@@ -131,7 +129,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.platform.target }}
+          target: aarch64-apple-darwin
           args: --release --out dist --find-interpreter
           working-directory: ./omf-python
           sccache: 'true'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,12 +116,14 @@ jobs:
       matrix:
         platform:
           - runner: macos-latest
+            target: arm64
+            cargo_target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-          architecture: arm64
+          architecture: ${{ matrix.platform.target }}
       - uses: actions/download-artifact@v4
         with:
           name: omf-python-stub
@@ -129,7 +131,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: aarch64-apple-darwin
+          target: ${{ matrix.platform.cargo_target }}
           args: --release --out dist --find-interpreter
           working-directory: ./omf-python
           sccache: 'true'

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -109,6 +109,38 @@ jobs:
           name: wheels-windows-${{ matrix.platform.target }}
           path: omf-python/dist
 
+  mac:
+    runs-on: ${{ matrix.platform.runner }}
+    needs: [ python-stub-file ]
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-latest
+            # Assume M1+ chips going forwards for Mac, do not build for Intel
+            target: arm64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+          architecture: ${{ matrix.platform.target }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: omf-python-stub
+          path: omf-python
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter
+          working-directory: ./omf-python
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: omf-python/dist
+
   # release:
   #   name: Release
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
Macs have two processor types, previously Intel, more recently Apple M1 (and up). This PR assumes that M1+ chips will be the standard for Mac going forwards and so does not build for Intel chips. We can add a separate build for those if someone needs them, but it should become less common going forwards.