### PR TITLE
Renamed the Python package to omf2.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,24 +16,24 @@ permissions:
 
 jobs:
   python-stub-file:
-    name: Generate and upload omf_python.pyi
+    name: Generate and upload omf2.pyi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.85.0
-      - name: Build omf_python for stub information
+      - name: Build omf2 for stub information
         working-directory: ./omf-python
         run: cargo build
-      - name: Generate omf_python.pyi
+      - name: Generate omf2.pyi
         working-directory: ./omf-python
         run: cargo run --bin stub_gen
-      - name: Upload omf_python.pyi
+      - name: Upload omf2.pyi
         uses: actions/upload-artifact@v4
         with:
           name: omf-python-stub
-          path: omf-python/omf_python.pyi
+          path: omf-python/omf2.pyi
 
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -73,7 +73,7 @@ jobs:
           set -e
           python3 -m venv .venv
           source .venv/bin/activate
-          pip install omf_python --find-links dist --force-reinstall
+          pip install omf2 --find-links dist --force-reinstall
           pip install numpy
           pip install pytest
           pytest

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ Cargo.lock
 /omf-python/venv
 /omf-python/docs/build
 /omf-python/tests/__pycache__/
-/omf-python/omf_python.pyi
+/omf-python/omf2.pyi

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -1,5 +1,5 @@
 # OMF Python API
 
-::: omf_python
+::: omf2
     options:
       heading_level: 2

--- a/omf-python/Cargo.toml
+++ b/omf-python/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "omf_python"
+name = "omf2"
 description = "Python bindings for the Rust OMF package."
 publish = false
 version.workspace = true
@@ -26,7 +26,7 @@ itertools.workspace = true
 omf = { path = ".." }
 
 [lib]
-name = "omf_python"
+name = "omf2"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 

--- a/omf-python/README.md
+++ b/omf-python/README.md
@@ -19,8 +19,8 @@ $ python
 
 Python 3.12.5 (main, Aug  6 2024, 19:08:49) [GCC 11.4.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
->>> import omf_python
->>> reader = omf_python.Reader("../target/tmp/one_of_everything.omf")
+>>> import omf2
+>>> reader = omf2.Reader("../target/tmp/one_of_everything.omf")
 >>> for element in reader.project.elements:
 ...     print(element.geometry.get_type())
 ...
@@ -53,8 +53,8 @@ cd omf-python
 cargo run --bin stub_gen
 ```
 
-This will create a file `omf_python.pyi` which will get included automatically the next time you run `maturin develop`.
-Afterwards you should be able to see comments and typing information about omf_python in your editor.
+This will create a file `omf2.pyi` which will get included automatically the next time you run `maturin develop`.
+Afterwards you should be able to see comments and typing information about omf2 in your editor.
 
 Some test OMF files need to be generated so that all features can be tested via `pytest`. If you need to make more test
 files, or modify existing ones:

--- a/omf-python/pyproject.toml
+++ b/omf-python/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["maturin>=1,<2"]
 build-backend = "maturin"
 
 [project]
-name = "omf_python"
-requires-python = ">=3.7"
+name = "omf2"
+requires-python = ">=3.9"
 dynamic = ["version"]
 
 [tool.maturin]

--- a/omf-python/src/bin/stub_gen.rs
+++ b/omf-python/src/bin/stub_gen.rs
@@ -2,7 +2,7 @@ use pyo3_stub_gen::Result;
 
 fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().filter_or("RUST_LOG", "info")).init();
-    let stub = omf_python::stub_info()?;
+    let stub = omf2::stub_info()?;
     stub.generate()?;
     // Copy the crate docs from the top of lib.rs and add them to the stub.
     let mut docs = String::new();
@@ -13,8 +13,8 @@ fn main() -> Result<()> {
             docs.push('\n');
         }
     }
-    let mut pyi = std::fs::read_to_string("omf_python.pyi").expect("Failed to read stub");
+    let mut pyi = std::fs::read_to_string("omf2.pyi").expect("Failed to read stub");
     pyi = format!("r\"\"\"\n{docs}\"\"\"\n\n{pyi}");
-    std::fs::write("omf_python.pyi", pyi).expect("Failed to re-write stub");
+    std::fs::write("omf2.pyi", pyi).expect("Failed to re-write stub");
     Ok(())
 }

--- a/omf-python/src/errors.rs
+++ b/omf-python/src/errors.rs
@@ -22,10 +22,10 @@ macro_rules! create_exception_impl {
 }
 
 // NOTE: OmfException needs to be first alphabetically for the exceptions show correctly
-// in the Sphinx documentation as that is the order they get added into omf_python.pyi.
+// in the Sphinx documentation as that is the order they get added into omf2.pyi.
 
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfException,
     PyException,
     "Exception",
@@ -33,28 +33,28 @@ create_exception_impl!(
 );
 
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfFileIoException,
     OmfException,
     "OmfException",
     "Exception raised when a file IO error occurs."
 );
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfJsonException,
     OmfException,
     "OmfException",
     "Exception raised when a JSON error occurs. Can also be triggered by exceeding the `json_bytes` safety limit."
 );
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfLimitExceededException,
     OmfException,
     "OmfException",
     "Exception raised when a safety limit was exceeded."
 );
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfInvalidDataException,
     OmfException,
     "OmfException",
@@ -62,14 +62,14 @@ create_exception_impl!(
 );
 
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfValidationFailedException,
     OmfException,
     "OmfException",
     "Exception raised when an OMF validation error occurs."
 );
 create_exception_impl!(
-    omf_python,
+    omf2,
     OmfNotSupportedException,
     OmfException,
     "OmfException",

--- a/omf-python/src/lib.rs
+++ b/omf-python/src/lib.rs
@@ -87,7 +87,7 @@ fn version() -> String {
 
 /// This module provides python bindings for omf-rust.
 #[pymodule]
-fn omf_python(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn omf2(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<array::PyBooleanArray>()?;
     m.add_class::<array::PyBoundaryArray>()?;
     m.add_class::<array::PyColorArray>()?;

--- a/omf-python/tests/test_block_model.py
+++ b/omf-python/tests/test_block_model.py
@@ -2,7 +2,7 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestBlockModel(TestCase):
@@ -11,10 +11,10 @@ class TestBlockModel(TestCase):
         self.one_of_everything = path.join(self.omf_dir, "one_of_everything.omf")
 
     def test_should_return_expected_regular_block_model(self) -> None:
-        reader = omf_python.Reader(self.one_of_everything)
+        reader = omf2.Reader(self.one_of_everything)
         project, _ = reader.project()
-        block_model: omf_python.BlockModel = project.elements()[4].geometry()
-        self.assertIsInstance(block_model, omf_python.BlockModel)
+        block_model: omf2.BlockModel = project.elements()[4].geometry()
+        self.assertIsInstance(block_model, omf2.BlockModel)
 
         orientation = block_model.orient
         self.assertTrue(numpy.array_equal([-1, -1, -1], orientation.origin))
@@ -23,7 +23,7 @@ class TestBlockModel(TestCase):
         self.assertTrue(numpy.array_equal([0, 0, 1], orientation.w))
 
         grid = block_model.grid
-        self.assertIsInstance(grid, omf_python.Grid3Regular)
+        self.assertIsInstance(grid, omf2.Grid3Regular)
         self.assertEqual([1, 1, 1], grid.size)
         self.assertEqual([2, 2, 2], grid.count())
         self.assertEqual(8, grid.flat_count())
@@ -33,55 +33,55 @@ class TestBlockModel(TestCase):
         self.assertIsNone(subblocks)
 
     def test_should_have_expected_tensor_block_model(self) -> None:
-        reader = omf_python.Reader(self.one_of_everything)
+        reader = omf2.Reader(self.one_of_everything)
         project, _ = reader.project()
-        block_model: omf_python.BlockModel = project.elements()[5].geometry()
-        self.assertIsInstance(block_model, omf_python.BlockModel)
+        block_model: omf2.BlockModel = project.elements()[5].geometry()
+        self.assertIsInstance(block_model, omf2.BlockModel)
 
         grid = block_model.grid
-        self.assertIsInstance(grid, omf_python.Grid3Tensor)
+        self.assertIsInstance(grid, omf2.Grid3Tensor)
         self.assertEqual([2, 2, 2], grid.count())
         self.assertEqual(8, grid.flat_count())
         self.assertEqual(27, grid.flat_corner_count())
 
         u = grid.u
-        self.assertIsInstance(u, omf_python.ScalarArray)
+        self.assertIsInstance(u, omf2.ScalarArray)
         self.assertEqual(2, u.item_count())
         u_scalars = reader.array_scalars(u)
         self.assertEqual(numpy.float64, u_scalars.dtype)
         self.assertTrue(numpy.array_equal([0.6666, 1.333], u_scalars))
 
         v = grid.v
-        self.assertIsInstance(v, omf_python.ScalarArray)
+        self.assertIsInstance(v, omf2.ScalarArray)
         self.assertEqual(2, v.item_count())
         v_scalars = reader.array_scalars(v)
         self.assertEqual(numpy.float64, v_scalars.dtype)
         self.assertTrue(numpy.array_equal([0.6666, 1.333], v_scalars))
 
         w = grid.w
-        self.assertIsInstance(w, omf_python.ScalarArray)
+        self.assertIsInstance(w, omf2.ScalarArray)
         self.assertEqual(2, w.item_count())
         w_scalars = reader.array_scalars(w)
         self.assertEqual(numpy.float64, w_scalars.dtype)
         self.assertTrue(numpy.array_equal([1.0, 1.0], w_scalars))
 
     def test_should_have_expected_regular_subblocks(self) -> None:
-        reader = omf_python.Reader(self.one_of_everything)
+        reader = omf2.Reader(self.one_of_everything)
         project, _ = reader.project()
-        block_model: omf_python.BlockModel = project.elements()[6].geometry()
-        self.assertIsInstance(block_model, omf_python.BlockModel)
+        block_model: omf2.BlockModel = project.elements()[6].geometry()
+        self.assertIsInstance(block_model, omf2.BlockModel)
 
         regular_subblocks = block_model.subblocks
-        self.assertIsInstance(regular_subblocks, omf_python.RegularSubblocks)
+        self.assertIsInstance(regular_subblocks, omf2.RegularSubblocks)
 
-        expected_mode = omf_python.SubblockMode.Octree
+        expected_mode = omf2.SubblockMode.Octree
         self.assertEqual(expected_mode, regular_subblocks.mode)
 
         expected_count = [4, 4, 4]
         self.assertEqual(expected_count, regular_subblocks.count)
 
         subblocks_array = regular_subblocks.subblocks
-        self.assertIsInstance(subblocks_array, omf_python.RegularSubblockArray)
+        self.assertIsInstance(subblocks_array, omf2.RegularSubblockArray)
 
         expected_regular_subblock_parents = numpy.array(
             [
@@ -131,16 +131,16 @@ class TestBlockModel(TestCase):
         )
 
     def test_should_have_expected_freeform_subblocks(self) -> None:
-        reader = omf_python.Reader(self.one_of_everything)
+        reader = omf2.Reader(self.one_of_everything)
         project, _ = reader.project()
-        block_model: omf_python.BlockModel = project.elements()[7].geometry()
-        self.assertIsInstance(block_model, omf_python.BlockModel)
+        block_model: omf2.BlockModel = project.elements()[7].geometry()
+        self.assertIsInstance(block_model, omf2.BlockModel)
 
         freeform_subblocks = block_model.subblocks
-        self.assertIsInstance(freeform_subblocks, omf_python.FreeformSubblocks)
+        self.assertIsInstance(freeform_subblocks, omf2.FreeformSubblocks)
 
         subblocks_array = freeform_subblocks.subblocks
-        self.assertIsInstance(subblocks_array, omf_python.FreeformSubblockArray)
+        self.assertIsInstance(subblocks_array, omf2.FreeformSubblockArray)
 
         expected_freeform_subblock_parents = numpy.array(
             [

--- a/omf-python/tests/test_boolean_attribute.py
+++ b/omf-python/tests/test_boolean_attribute.py
@@ -2,23 +2,21 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestBooleanAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
 
         # Get the "Regular block model" element, and its "Filter" attribute.
         self.attribute = self.project.elements()[4].attributes()[0]
 
     def test_should_return_boolean_attribute_instance(self) -> None:
-        self.assertIsInstance(
-            self.attribute.get_data(), omf_python.AttributeDataBoolean
-        )
+        self.assertIsInstance(self.attribute.get_data(), omf2.AttributeDataBoolean)
 
     def test_should_return_boolean_attribute_values_item_count(self) -> None:
         actual_count = self.attribute.get_data().values.item_count()

--- a/omf-python/tests/test_category_attribute.py
+++ b/omf-python/tests/test_category_attribute.py
@@ -2,19 +2,19 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestCategoryAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[1].attributes()[0]
 
     def test_should_return_category_attribute_details(self) -> None:
-        self.assertIsInstance(self.attribute, omf_python.Attribute)
+        self.assertIsInstance(self.attribute, omf2.Attribute)
 
         self.assertEqual(self.attribute.name, "Categories")
         self.assertEqual(
@@ -25,17 +25,17 @@ class TestCategoryAttribute(TestCase):
         expected_metadata = {"key": "value"}
         self.assertDictEqual(self.attribute.metadata, expected_metadata)
 
-        self.assertEqual(self.attribute.location, omf_python.Location.Vertices)
+        self.assertEqual(self.attribute.location, omf2.Location.Vertices)
 
     def test_should_return_category_attribute_array_instances(self) -> None:
         attribute_data = self.attribute.get_data()
 
-        self.assertIsInstance(attribute_data, omf_python.AttributeDataCategory)
+        self.assertIsInstance(attribute_data, omf2.AttributeDataCategory)
 
-        self.assertIsInstance(attribute_data.values, omf_python.IndexArray)
-        self.assertIsInstance(attribute_data.names, omf_python.NameArray)
-        self.assertIsInstance(attribute_data.gradient, omf_python.GradientArray)
-        self.assertIsInstance(attribute_data.attributes[0], omf_python.Attribute)
+        self.assertIsInstance(attribute_data.values, omf2.IndexArray)
+        self.assertIsInstance(attribute_data.names, omf2.NameArray)
+        self.assertIsInstance(attribute_data.gradient, omf2.GradientArray)
+        self.assertIsInstance(attribute_data.attributes[0], omf2.Attribute)
 
     def test_should_return_category_attribute_expected_values(self) -> None:
         attribute_data = self.attribute.get_data()
@@ -63,4 +63,4 @@ class TestCategoryAttribute(TestCase):
         category_attributes = attribute_data.attributes
 
         self.assertEqual(len(category_attributes), 1)
-        self.assertIsInstance(category_attributes[0], omf_python.Attribute)
+        self.assertIsInstance(category_attributes[0], omf2.Attribute)

--- a/omf-python/tests/test_color_attribute.py
+++ b/omf-python/tests/test_color_attribute.py
@@ -2,14 +2,14 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestColorAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[0].attributes()[1]
 

--- a/omf-python/tests/test_element.py
+++ b/omf-python/tests/test_element.py
@@ -1,14 +1,14 @@
 from os import path
 from unittest import TestCase
 
-import omf_python
+import omf2
 
 
 class TestElement(TestCase):
     def test_should_return_expected_element_metadata(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
 
-        reader = omf_python.Reader(path.join(omf_dir, "element_metadata.omf"))
+        reader = omf2.Reader(path.join(omf_dir, "element_metadata.omf"))
         project, _ = reader.project()
 
         element = project.elements()[0]

--- a/omf-python/tests/test_geometry_surface.py
+++ b/omf-python/tests/test_geometry_surface.py
@@ -2,7 +2,7 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestGeometrySurface(TestCase):
@@ -14,12 +14,12 @@ class TestGeometrySurface(TestCase):
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
 
         # When
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
         project, _ = reader.project()
 
-        # Geometry is an instance of omf_python.Surface
+        # Geometry is an instance of omf2.Surface
         surface = project.elements()[0].geometry()
-        self.assertIsInstance(surface, omf_python.Surface)
+        self.assertIsInstance(surface, omf2.Surface)
 
         # And it contains 6 triangles
         triangles_array = surface.triangles
@@ -62,7 +62,7 @@ class TestGeometrySurface(TestCase):
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
 
         # When
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
         project, _ = reader.project()
 
         surface = project.elements()[0]

--- a/omf-python/tests/test_grid_surface.py
+++ b/omf-python/tests/test_grid_surface.py
@@ -2,7 +2,7 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestGridSurface(TestCase):
@@ -11,10 +11,10 @@ class TestGridSurface(TestCase):
         self.one_of_everything = path.join(self.omf_dir, "one_of_everything.omf")
 
     def test_should_contain_grid_surface_geometry(self) -> None:
-        reader = omf_python.Reader(self.one_of_everything)
+        reader = omf2.Reader(self.one_of_everything)
         project, _ = reader.project()
         grid_surface = project.elements()[3].geometry()
-        self.assertIsInstance(grid_surface, omf_python.GridSurface)
+        self.assertIsInstance(grid_surface, omf2.GridSurface)
 
         orientation = grid_surface.orient
         self.assertTrue(numpy.array_equal([-1.5, -1.5, 0], orientation.origin))
@@ -33,18 +33,18 @@ class TestGridSurface(TestCase):
         )
 
         grid = grid_surface.grid
-        self.assertIsInstance(grid, omf_python.Grid2Tensor)
+        self.assertIsInstance(grid, omf2.Grid2Tensor)
         self.assertEqual([2, 2], grid.count())
 
         u = grid.u
-        self.assertIsInstance(u, omf_python.ScalarArray)
+        self.assertIsInstance(u, omf2.ScalarArray)
         self.assertEqual(2, u.item_count())
         u_scalars = reader.array_scalars(u)
         self.assertEqual(numpy.float64, u_scalars.dtype)
         self.assertTrue(numpy.array_equal([1, 2], u_scalars))
 
         v = grid.v
-        self.assertIsInstance(v, omf_python.ScalarArray)
+        self.assertIsInstance(v, omf2.ScalarArray)
         self.assertEqual(2, v.item_count())
         v_scalars = reader.array_scalars(v)
         self.assertEqual(numpy.float64, v_scalars.dtype)

--- a/omf-python/tests/test_lineset.py
+++ b/omf-python/tests/test_lineset.py
@@ -2,19 +2,19 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestLineSet(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.lineset = self.project.elements()[2]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        self.assertIsInstance(self.lineset.geometry(), omf_python.LineSet)
+        self.assertIsInstance(self.lineset.geometry(), omf2.LineSet)
 
     def test_should_return_expected_origin(self) -> None:
         lineset_origin = self.lineset.geometry().origin

--- a/omf-python/tests/test_mapped_texture_attibute.py
+++ b/omf-python/tests/test_mapped_texture_attibute.py
@@ -2,14 +2,14 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestMappedTextureAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[9].attributes()[1]
 

--- a/omf-python/tests/test_number_attribute.py
+++ b/omf-python/tests/test_number_attribute.py
@@ -3,8 +3,8 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
-from omf_python import BoundaryType
+import omf2
+from omf2 import BoundaryType
 
 
 class TestNumberAttribute(TestCase):
@@ -13,15 +13,15 @@ class TestNumberAttribute(TestCase):
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
         continuous_colormap = path.join(omf_dir, "continuous_colormap.omf")
 
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[0].attributes()[2]
 
-        self.ccmap_reader = omf_python.Reader(continuous_colormap)
+        self.ccmap_reader = omf2.Reader(continuous_colormap)
         self.ccmap_project, _ = self.ccmap_reader.project()
 
     def test_should_return_number_attribute_instance(self) -> None:
-        self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataNumber)
+        self.assertIsInstance(self.attribute.get_data(), omf2.AttributeDataNumber)
 
     def test_should_return_number_attribute_values(self) -> None:
         attribute_data = self.attribute.get_data()
@@ -53,9 +53,9 @@ class TestNumberAttribute(TestCase):
     def test_should_return_discrete_colormap(self) -> None:
         colormap = self.attribute.get_data().colormap
 
-        self.assertIsInstance(colormap, omf_python.NumberColormapDiscrete)
-        self.assertIsInstance(colormap.boundaries, omf_python.BoundaryArray)
-        self.assertIsInstance(colormap.gradient, omf_python.GradientArray)
+        self.assertIsInstance(colormap, omf2.NumberColormapDiscrete)
+        self.assertIsInstance(colormap.boundaries, omf2.BoundaryArray)
+        self.assertIsInstance(colormap.gradient, omf2.GradientArray)
 
     def test_should_return_discrete_colormap_boundaries(self) -> None:
         boundary_array = self.attribute.get_data().colormap.boundaries
@@ -94,8 +94,8 @@ class TestNumberAttribute(TestCase):
     def test_should_return_continuous_colormap(self) -> None:
         colormap = self.ccmap_project.elements()[0].attributes()[0].get_data().colormap
 
-        self.assertIsInstance(colormap, omf_python.NumberColormapContinuous)
-        self.assertIsInstance(colormap.gradient, omf_python.GradientArray)
+        self.assertIsInstance(colormap, omf2.NumberColormapContinuous)
+        self.assertIsInstance(colormap.gradient, omf2.GradientArray)
 
     def test_should_return_continuous_colormap_float_range(self) -> None:
         min, max = (

--- a/omf-python/tests/test_omf1_converter.py
+++ b/omf-python/tests/test_omf1_converter.py
@@ -2,7 +2,7 @@ from os import path
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-import omf_python
+import omf2
 
 
 class TestOmf1Converter(TestCase):
@@ -12,25 +12,25 @@ class TestOmf1Converter(TestCase):
     def test_should_convert_omf1_to_omf2_file(self) -> None:
         # Given
         omf1_file = path.join(self.test_data_dir, "omf1/test_proj.omf")
-        self.assertTrue(omf_python.detect_omf1(omf1_file))
+        self.assertTrue(omf2.detect_omf1(omf1_file))
 
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
             # When
             converter.convert(omf1_file, omf2_file.name)
 
             # Then
-            reader = omf_python.Reader(omf2_file.name)
+            reader = omf2.Reader(omf2_file.name)
             project, _ = reader.project()
             self.assertEqual(len(project.elements()), 2)
 
     def test_should_return_expected_problems(self) -> None:
         # Given
         omf1_file = path.join(self.test_data_dir, "omf1/test_proj.omf")
-        self.assertTrue(omf_python.detect_omf1(omf1_file))
+        self.assertTrue(omf2.detect_omf1(omf1_file))
 
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         # When
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
@@ -55,11 +55,11 @@ class TestOmf1Converter(TestCase):
         # Given
         omf1_file = path.join(self.test_data_dir, "omf1/testfilenotfound.omf")
 
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
             # When
-            with self.assertRaises(omf_python.OmfFileIoException) as context:
+            with self.assertRaises(omf2.OmfFileIoException) as context:
                 converter.convert(omf1_file, omf2_file.name)
 
             # Then
@@ -67,7 +67,7 @@ class TestOmf1Converter(TestCase):
 
     def test_should_return_expected_default_limits(self) -> None:
         # Given
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         # When
         limits = converter.limits()
@@ -80,9 +80,9 @@ class TestOmf1Converter(TestCase):
 
     def test_should_set_limits(self) -> None:
         # Given
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
-        limits = omf_python.Limits()
+        limits = omf2.Limits()
         limits.json_bytes = 1
         limits.image_bytes = 2
         limits.image_dim = 3
@@ -99,23 +99,23 @@ class TestOmf1Converter(TestCase):
         self.assertEqual(updated_limits.validation, limits.validation)
 
     def test_should_raise_exception_if_limit_invalid(self) -> None:
-        limits = omf_python.Limits()
+        limits = omf2.Limits()
         with self.assertRaises(OverflowError):
             limits.json_bytes = -1
 
     def test_should_raise_exception_if_json_bytes_limit_reached(self) -> None:
         # Given
         omf1_file = path.join(self.test_data_dir, "omf1/test_proj.omf")
-        self.assertTrue(omf_python.detect_omf1(omf1_file))
+        self.assertTrue(omf2.detect_omf1(omf1_file))
 
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
         limits = converter.limits()
         limits.json_bytes = 0
 
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
             # When
             converter.set_limits(limits)
-            with self.assertRaises(omf_python.OmfLimitExceededException) as context:
+            with self.assertRaises(omf2.OmfLimitExceededException) as context:
                 converter.convert(omf1_file, omf2_file.name)
 
             # Then
@@ -123,7 +123,7 @@ class TestOmf1Converter(TestCase):
 
     def test_should_get_compression(self) -> None:
         # Given
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         # When
         compression = converter.compression()
@@ -133,7 +133,7 @@ class TestOmf1Converter(TestCase):
 
     def test_should_set_compression(self) -> None:
         # Given
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         # When
         converter.set_compression(9)
@@ -143,7 +143,7 @@ class TestOmf1Converter(TestCase):
 
     def test_should_limit_max_compression(self) -> None:
         # Given
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
 
         # When
         converter.set_compression(10)
@@ -154,20 +154,20 @@ class TestOmf1Converter(TestCase):
     def test_high_compression_reduces_file_size(self) -> None:
         # Given
         omf1_file = path.join(self.test_data_dir, "omf1/test_proj.omf")
-        converter = omf_python.Omf1Converter()
+        converter = omf2.Omf1Converter()
         converter.set_compression(0)
 
         # When
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
             converter.convert(omf1_file, omf2_file.name)
-            omf_python.Reader(omf2_file.name)
+            omf2.Reader(omf2_file.name)
             low_compression_file_size = path.getsize(omf2_file.name)
 
         converter.set_compression(9)
 
         with NamedTemporaryFile(suffix=".omf") as omf2_file:
             converter.convert(omf1_file, omf2_file.name)
-            omf_python.Reader(omf2_file.name)
+            omf2.Reader(omf2_file.name)
             high_compression_file_size = path.getsize(omf2_file.name)
 
         # Then

--- a/omf-python/tests/test_pointset.py
+++ b/omf-python/tests/test_pointset.py
@@ -2,19 +2,19 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestPointSet(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.pointset = self.project.elements()[1]
 
     def test_should_return_expected_geometry_type(self) -> None:
-        self.assertIsInstance(self.pointset.geometry(), omf_python.PointSet)
+        self.assertIsInstance(self.pointset.geometry(), omf2.PointSet)
 
     def test_should_return_expected_origin(self) -> None:
         pointset_origin = self.pointset.geometry().origin

--- a/omf-python/tests/test_project.py
+++ b/omf-python/tests/test_project.py
@@ -2,14 +2,14 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestProject(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "../../examples")
         pyramid = path.join(omf_dir, "pyramid/pyramid.omf")
-        self.reader = omf_python.Reader(pyramid)
+        self.reader = omf2.Reader(pyramid)
 
     def test_should_return_expected_project_details(self) -> None:
         # Given I have loaded a project
@@ -34,6 +34,6 @@ class TestProject(TestCase):
         # Then I should have two elements
         self.assertEqual(len(elements), 2)
 
-        # And those elements should be of type omf_python.Element
+        # And those elements should be of type omf2.Element
         for element in elements:
-            self.assertIsInstance(element, omf_python.Element)
+            self.assertIsInstance(element, omf2.Element)

--- a/omf-python/tests/test_projected_texture_attribute.py
+++ b/omf-python/tests/test_projected_texture_attribute.py
@@ -2,14 +2,14 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestProjectedTextureAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[9].attributes()[0]
 

--- a/omf-python/tests/test_reader.py
+++ b/omf-python/tests/test_reader.py
@@ -1,7 +1,7 @@
 from os import path
 from unittest import TestCase
 
-import omf_python
+import omf2
 
 
 class TestReader(TestCase):
@@ -13,7 +13,7 @@ class TestReader(TestCase):
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
 
         # When
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
 
         # Then
         self.assertEqual(reader.version(), [2, 0])
@@ -26,9 +26,9 @@ class TestReader(TestCase):
         onf_file_with_error = path.join(
             path.dirname(__file__), "data/missing_parquet.omf"
         )
-        reader = omf_python.Reader(onf_file_with_error)
+        reader = omf2.Reader(onf_file_with_error)
 
-        with self.assertRaises(omf_python.OmfValidationFailedException) as context:
+        with self.assertRaises(omf2.OmfValidationFailedException) as context:
             reader.project()
 
         self.assertEqual(
@@ -42,7 +42,7 @@ class TestReader(TestCase):
         onf_file_with_problem = path.join(
             path.dirname(__file__), "data/duplicate_element_name.omf"
         )
-        reader = omf_python.Reader(onf_file_with_problem)
+        reader = omf2.Reader(onf_file_with_problem)
         _, problems = reader.project()
 
         # Then
@@ -66,12 +66,12 @@ class TestReader(TestCase):
             path.dirname(__file__), "data/array_length_mismatch.omf"
         )
 
-        reader = omf_python.Reader(onf_file_with_array_length_mismatch)
+        reader = omf2.Reader(onf_file_with_array_length_mismatch)
         project, _ = reader.project()
         vertices_array = project.elements()[0].geometry().vertices
 
         # When
-        with self.assertRaises(omf_python.OmfInvalidDataException) as context:
+        with self.assertRaises(omf2.OmfInvalidDataException) as context:
             reader.array_vertices(vertices_array)
 
         # Then
@@ -85,8 +85,8 @@ class TestReader(TestCase):
         incorrect_location = path.join(self.examples_dir, "testfilenotfound.omf")
 
         # When
-        with self.assertRaises(omf_python.OmfFileIoException) as context:
-            omf_python.Reader(incorrect_location)
+        with self.assertRaises(omf2.OmfFileIoException) as context:
+            omf2.Reader(incorrect_location)
 
         # Then
         self.assertIn("(os error 2)", str(context.exception))
@@ -94,7 +94,7 @@ class TestReader(TestCase):
     def test_should_return_expected_default_limits(self) -> None:
         # Given
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
 
         # When
         limits = reader.limits()
@@ -108,9 +108,9 @@ class TestReader(TestCase):
     def test_should_set_limits(self) -> None:
         # Given
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
 
-        limits = omf_python.Limits()
+        limits = omf2.Limits()
         limits.json_bytes = 1
         limits.image_bytes = 2
         limits.image_dim = 3
@@ -129,14 +129,14 @@ class TestReader(TestCase):
     def test_should_raise_exception_if_json_bytes_limit_reached(self) -> None:
         # Given
         omf_file = path.join(self.examples_dir, "pyramid/pyramid.omf")
-        reader = omf_python.Reader(omf_file)
+        reader = omf2.Reader(omf_file)
 
         limits = reader.limits()
         limits.json_bytes = 0
 
         # When
         reader.set_limits(limits)
-        with self.assertRaises(omf_python.OmfJsonException) as context:
+        with self.assertRaises(omf2.OmfJsonException) as context:
             reader.project()
 
         # Then

--- a/omf-python/tests/test_text_attribute.py
+++ b/omf-python/tests/test_text_attribute.py
@@ -1,21 +1,21 @@
 from os import path
 from unittest import TestCase
 
-import omf_python
+import omf2
 
 
 class TestTextAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
 
         # Get the "Pyramid Lines" element, and its "Strings" attribute.
         self.attribute = self.project.elements()[2].attributes()[0]
 
     def test_should_return_text_attribute_instance(self) -> None:
-        self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataText)
+        self.assertIsInstance(self.attribute.get_data(), omf2.AttributeDataText)
 
     def test_should_return_text_attribute_values_item_count(self) -> None:
         actual_count = self.attribute.get_data().values.item_count()

--- a/omf-python/tests/test_vector_attribute.py
+++ b/omf-python/tests/test_vector_attribute.py
@@ -2,19 +2,19 @@ from os import path
 from unittest import TestCase
 
 import numpy
-import omf_python
+import omf2
 
 
 class TestVectorAttribute(TestCase):
     def setUp(self) -> None:
         omf_dir = path.join(path.dirname(__file__), "data")
         one_of_everything = path.join(omf_dir, "one_of_everything.omf")
-        self.reader = omf_python.Reader(one_of_everything)
+        self.reader = omf2.Reader(one_of_everything)
         self.project, _ = self.reader.project()
         self.attribute = self.project.elements()[1].attributes()[1]
 
     def test_should_return_vector_attribute_instance(self) -> None:
-        self.assertIsInstance(self.attribute.get_data(), omf_python.AttributeDataVector)
+        self.assertIsInstance(self.attribute.get_data(), omf2.AttributeDataVector)
 
     def test_should_return_vector_attribute_values(self) -> None:
         attribute_data = self.attribute.get_data()


### PR DESCRIPTION
Renames the Python package to `omf2` and fixes everything to work afterwards.

Using `omf2` will allow it to be installed at the same time as the existing `omf` package for OMF v1.