### PR TITLE
Swap mkdocs theme for Material

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 set -e
 python -m pip install -r requirements.txt
 cd ..

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs
 mkdocs-material
-mkdocstrings-python>=1.15.0
+mkdocstrings-python>=1.16.8
 markdown-callouts
 python-markdown-math
 pymdown-extensions

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 mkdocs
+mkdocs-material
 mkdocstrings-python>=1.15.0
 markdown-callouts
 python-markdown-math

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,20 @@
-dd {
-    margin-left: 2em;
+/* Indent all content underneath h2 slightly. h1 and description should remain unindented. */
+.md-content__inner > dl,
+.md-content__inner dd,
+.md-content__inner > .admonition,
+[dir=ltr] .md-content__inner > ol,
+[dir=ltr] .md-content__inner > ul,
+.md-content__inner > *:not(h1):not(h2):not(h3):not(.doc) {
+    margin-left: 1.875em;
+}
+
+.md-content__inner > h3 {
+    margin-left: 1.4em;
+}
+
+/* Python docs */
+.doc-class >.doc-contents,
+.doc-class .doc-object,
+.doc-function > .doc-contents {
+    margin-left: 1.875em;
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -4,3 +4,8 @@
 .doc-function > .doc-contents {
     margin-left: 1.875em;
 }
+
+/* Hide sub-navs, we only want the top level item */
+[data-md-component="toc"] .md-nav .md-nav {
+    display: none;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,17 +1,3 @@
-/* Indent all content underneath h2 slightly. h1 and description should remain unindented. */
-.md-content__inner > dl,
-.md-content__inner dd,
-.md-content__inner > .admonition,
-[dir=ltr] .md-content__inner > ol,
-[dir=ltr] .md-content__inner > ul,
-.md-content__inner > *:not(h1):not(h2):not(h3):not(.doc) {
-    margin-left: 1.875em;
-}
-
-.md-content__inner > h3 {
-    margin-left: 1.4em;
-}
-
 /* Python docs */
 .doc-class >.doc-contents,
 .doc-class .doc-object,

--- a/docs/templates/python/material/_base/children.html.jinja
+++ b/docs/templates/python/material/_base/children.html.jinja
@@ -1,0 +1,154 @@
+{#- Template for members (children) of an object.
+
+This template iterates on members of a given object and renders them.
+It can group members by category (attributes, classes, functions, modules) or render them in a flat list.
+
+Context:
+  obj (griffe.Object): The object to render.
+  config (dict): The configuration options.
+  root_members (bool): Whether the object is the root object.
+  heading_level (int): The HTML heading level to use.
+-#}
+
+{% if obj.all_members %}
+  {% block logs scoped %}
+    {#- Logging block.
+
+    This block can be used to log debug messages, deprecation messages, warnings, etc.
+    -#}
+    {{ log.debug("Rendering children of " + obj.path) }}
+  {% endblock logs %}
+
+  <div class="doc doc-children">
+
+    {% if root_members %}
+      {% set members_list = config.members %}
+    {% else %}
+      {% set members_list = none %}
+    {% endif %}
+
+    {% if config.group_by_category %}
+
+      {% with %}
+
+        {% if config.show_category_heading %}
+          {% set extra_level = 1 %}
+        {% else %}
+          {% set extra_level = 0 %}
+        {% endif %}
+
+        {#- Here used to be a "with attributes" block, removed since we use the summary view #}
+
+        {% with classes = obj.classes|filter_objects(
+            filters=config.filters,
+            members_list=members_list,
+            inherited_members=config.inherited_members,
+            keep_no_docstrings=config.show_if_no_docstring,
+          ) %}
+          {% if classes %}
+            {% if config.show_category_heading %}
+              {% filter heading(heading_level, id=html_id ~ "-classes") %}Classes{% endfilter %}
+            {% endif %}
+            {% with heading_level = heading_level + extra_level %}
+              {% for class in classes|order_members(config.members_order, members_list) %}
+                {% if config.filters == "public" or members_list is not none or (not class.is_imported or class.is_public) %}
+                  {% include class|get_template with context %}
+                {% endif %}
+              {% endfor %}
+            {% endwith %}
+          {% endif %}
+        {% endwith %}
+
+        {% with functions = obj.functions|filter_objects(
+            filters=config.filters,
+            members_list=members_list,
+            inherited_members=config.inherited_members,
+            keep_no_docstrings=config.show_if_no_docstring,
+          ) %}
+          {% if functions %}
+            {% if config.show_category_heading %}
+              {% filter heading(heading_level, id=html_id ~ "-functions") %}Functions{% endfilter %}
+            {% endif %}
+            {% with heading_level = heading_level + extra_level %}
+              {% for function in functions|order_members(config.members_order, members_list) %}
+                {% if not (obj.kind.value == "class" and function.name == "__init__" and config.merge_init_into_class) %}
+                  {% if config.filters == "public" or members_list is not none or (not function.is_imported or function.is_public) %}
+                    {% include function|get_template with context %}
+                  {% endif %}
+                {% endif %}
+              {% endfor %}
+            {% endwith %}
+          {% endif %}
+        {% endwith %}
+
+        {% if config.show_submodules %}
+          {% with modules = obj.modules|filter_objects(
+              filters=config.filters,
+              members_list=members_list,
+              inherited_members=config.inherited_members,
+              keep_no_docstrings=config.show_if_no_docstring,
+            ) %}
+            {% if modules %}
+              {% if config.show_category_heading %}
+                {% filter heading(heading_level, id=html_id ~ "-modules") %}Modules{% endfilter %}
+              {% endif %}
+              {% with heading_level = heading_level + extra_level %}
+                {% for module in modules|order_members("alphabetical", members_list) %}
+                  {% if config.filters == "public" or members_list is not none or (not module.is_alias or module.is_public) %}
+                    {% include module|get_template with context %}
+                  {% endif %}
+                {% endfor %}
+              {% endwith %}
+            {% endif %}
+          {% endwith %}
+        {% endif %}
+
+      {% endwith %}
+
+    {% else %}
+
+      {% for child in obj.all_members
+          |filter_objects(
+            filters=config.filters,
+            members_list=members_list,
+            inherited_members=config.inherited_members,
+            keep_no_docstrings=config.show_if_no_docstring,
+            )
+          |order_members(config.members_order, members_list)
+        %}
+
+        {% if not (obj.is_class and child.name == "__init__" and config.merge_init_into_class) %}
+
+          {% if config.filters == "public" or members_list is not none or child.is_public %}
+            {% if child.is_attribute %}
+              {% with attribute = child %}
+                {% include attribute|get_template with context %}
+              {% endwith %}
+
+            {% elif child.is_class %}
+              {% with class = child %}
+                {% include class|get_template with context %}
+              {% endwith %}
+
+            {% elif child.is_function %}
+              {% with function = child %}
+                {% include function|get_template with context %}
+              {% endwith %}
+
+            {% elif child.is_module and config.show_submodules %}
+              {% with module = child %}
+                {% include module|get_template with context %}
+              {% endwith %}
+
+            {% endif %}
+          {% endif %}
+
+        {% endif %}
+
+      {% endfor %}
+
+    {% endif %}
+
+  </div>
+
+{% endif %}

--- a/docs/templates/python/material/_base/docstring/attributes.html.jinja
+++ b/docs/templates/python/material/_base/docstring/attributes.html.jinja
@@ -1,0 +1,114 @@
+{#- Overloaded from the default template exclusively to remove the : after the title  #}
+{#- Template for "Attributes" sections in docstrings.
+
+This template renders a list of documented attributes in the format
+specified with the [`docstring_section_style`][] configuration option.
+
+Context:
+  section (griffe.DocstringSectionAttributes): The section to render.
+-#}
+
+{% block logs scoped %}
+  {#- Logging block.
+
+  This block can be used to log debug messages, deprecation messages, warnings, etc.
+  -#}
+  {{ log.debug("Rendering attributes section") }}
+{% endblock logs %}
+
+{# YORE: Bump 2: Replace `"|get_template` with `.html.jinja"` within line. #}
+{% import "language"|get_template as lang with context %}
+{#- Language module providing the `t` translation method. -#}
+
+{% if config.docstring_section_style == "table" %}
+  {% block table_style scoped %}
+    {#- Block for the `table` section style. -#}
+    <p><span class="doc-section-title">{{ section.title or "Attributes" }}</span></p>
+    <table>
+      <thead>
+        <tr>
+          <th>{{ lang.t("Name") }}</th>
+          <th>{{ lang.t("Type") }}</th>
+          <th>{{ lang.t("Description") }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for attribute in section.value %}
+          <tr class="doc-section-item">
+            <td><code><autoref identifier="{{ obj.path }}.{{ attribute.name }}" optional hover>{{ attribute.name }}</autoref></code></td>
+            <td>
+              {% if attribute.annotation %}
+                {% with expression = attribute.annotation %}
+                  {# YORE: Bump 2: Replace `"|get_template` with `.html.jinja"` within line. #}
+                  <code>{% include "expression"|get_template with context %}</code>
+                {% endwith %}
+              {% endif %}
+            </td>
+            <td>
+              <div class="doc-md-description">
+                {{ attribute.description|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+              </div>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endblock table_style %}
+{% elif config.docstring_section_style == "list" %}
+  {% block list_style scoped %}
+    {#- Block for the `list` section style. -#}
+    <p><span class="doc-section-title">{{ section.title or lang.t("Attributes:") }}</span></p>
+    <ul>
+      {% for attribute in section.value %}
+        <li class="doc-section-item field-body">
+          <b><code><autoref identifier="{{ obj.path }}.{{ attribute.name }}" optional hover>{{ attribute.name }}</autoref></code></b>
+          {% if attribute.annotation %}
+            {% with expression = attribute.annotation %}
+              {# YORE: Bump 2: Replace `"|get_template` with `.html.jinja"` within line. #}
+              (<code>{% include "expression"|get_template with context %}</code>)
+            {% endwith %}
+          {% endif %}
+          –
+          <div class="doc-md-description">
+            {{ attribute.description|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endblock list_style %}
+{% elif config.docstring_section_style == "spacy" %}
+  {% block spacy_style scoped %}
+    {#- Block for the `spacy` section style. -#}
+    <table>
+      <thead>
+        <tr>
+          <th><span class="doc-section-title">{{ (section.title or lang.t("ATTRIBUTE")).rstrip(":").upper() }}</span></th>
+          <th><span>{{ lang.t("DESCRIPTION") }}</span></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for attribute in section.value %}
+          <tr class="doc-section-item">
+            <td><code><autoref identifier="{{ obj.path }}.{{ attribute.name }}" optional hover>{{ attribute.name }}</autoref></code></td>
+            <td class="doc-attribute-details">
+              <div class="doc-md-description">
+                {{ attribute.description|convert_markdown(heading_level, html_id, autoref_hook=autoref_hook) }}
+              </div>
+              <p>
+                {% if attribute.annotation %}
+                  <span class="doc-attribute-annotation">
+                    <b>TYPE:</b>
+                    {% with expression = attribute.annotation %}
+                      {# YORE: Bump 2: Replace `"|get_template` with `.html.jinja"` within line. #}
+                      <code>{% include "expression"|get_template with context %}</code>
+                    {% endwith %}
+                  </span>
+                {% endif %}
+              </p>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endblock spacy_style %}
+{% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ markdown_extensions:
 plugins:
     - mkdocstrings:
         enable_inventory: true
+        custom_templates: docs/templates
         default_handler: python
         handlers:
             python:
@@ -38,6 +39,8 @@ plugins:
                     - "!^__?" # Hide protected and private members
                     merge_init_into_class: true
                     show_if_no_docstring: true
+                    summary:
+                        attributes: true
 
 theme:
     name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,7 +40,7 @@ plugins:
                     show_if_no_docstring: true
 
 theme:
-    name: mkdocs
+    name: material
     navigation_depth: 3
 
 extra_css:


### PR DESCRIPTION
Changes:
* Add a cross environment compatible shebang to docs build script
* Swap mkdocs theme to Material

The sidebar for the Python docs contains many items. It does not scroll properly, as noted in https://github.com/mkdocs/mkdocs/issues/2780.
    
Swapping to use the Material theme is an easy change and looks better, in my opinion. The Material theme does not have the same scrolling issue.

![image](https://github.com/user-attachments/assets/d9aad68e-2ea7-4a60-ad7e-fdc0972d2b7c)

In the Python docs, we use the "summary" view for attributes, which includes auto linking to more info for the types. This works for local types, e.g. `Oreint3` or `ImageArray`, as well as native Python types.

![image](https://github.com/user-attachments/assets/88feb72f-0237-4043-a38d-20d5311c996b)

Unfortunately, Rust methods annotations on the class's attributes are not being picked up by the parser, so we don't have descriptions on class attributes yet. With the summary view in place, you can now click on the type of the attribute to get more information, including a description.